### PR TITLE
Step 05a: ParamTable and param_overrides validation

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -20,7 +20,16 @@ FetchContent_Declare(
   GIT_TAG v2.4.2
 )
 
-FetchContent_MakeAvailable(json cli11)
+FetchContent_Declare(
+  Catch2
+  GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+  GIT_TAG v3.5.2
+)
+
+# Disable Catch2's own tests
+set(CATCH_BUILD_TESTING OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(json cli11 Catch2)
 
 add_executable(rankd
   src/main.cpp
@@ -37,15 +46,16 @@ set_target_properties(rankd PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
 )
 
-# Test executable
-add_executable(rowset_tests
+# Test executable (Catch2)
+add_executable(rankd_tests
   tests/test_rowset.cpp
+  tests/test_param_table.cpp
   src/task_registry.cpp
 )
 
-target_include_directories(rowset_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
-target_link_libraries(rowset_tests PRIVATE nlohmann_json::nlohmann_json)
+target_include_directories(rankd_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(rankd_tests PRIVATE nlohmann_json::nlohmann_json Catch2::Catch2WithMain)
 
-set_target_properties(rowset_tests PROPERTIES
+set_target_properties(rankd_tests PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
 )

--- a/engine/include/executor.h
+++ b/engine/include/executor.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "param_table.h"
 #include "plan.h"
 #include "task_registry.h"
 #include <vector>
@@ -10,6 +11,6 @@ namespace rankd {
 void validate_plan(const Plan &plan);
 
 // Execute plan and return output RowSets (one per outputs entry).
-std::vector<RowSet> execute_plan(const Plan &plan);
+std::vector<RowSet> execute_plan(const Plan &plan, const ExecCtx &ctx);
 
 } // namespace rankd

--- a/engine/include/param_table.h
+++ b/engine/include/param_table.h
@@ -1,0 +1,234 @@
+#pragma once
+
+#include "param_registry.h"
+#include <cmath>
+#include <limits>
+#include <nlohmann/json.hpp>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+namespace rankd {
+
+// Null tag for explicit null values
+struct NullTag {};
+
+// ParamValue: monostate = unset, NullTag = explicit null, or typed value
+using ParamValue =
+    std::variant<std::monostate, NullTag, int64_t, double, bool, std::string>;
+
+// Lookup ParamMeta by name (linear scan, OK for MVP)
+inline const ParamMeta *findParamByName(std::string_view name) {
+  for (const auto &meta : kParamRegistry) {
+    if (meta.name == name) {
+      return &meta;
+    }
+  }
+  return nullptr;
+}
+
+// Validation helpers
+inline int64_t validateInt(const nlohmann::json &value,
+                           const std::string &param_name) {
+  if (!value.is_number()) {
+    throw std::runtime_error("param '" + param_name + "' must be int");
+  }
+  if (value.is_number_float()) {
+    double d = value.get<double>();
+    if (!std::isfinite(d)) {
+      throw std::runtime_error("param '" + param_name +
+                               "' must be finite number");
+    }
+    if (std::floor(d) != d) {
+      throw std::runtime_error("param '" + param_name + "' must be int");
+    }
+    if (d < static_cast<double>(std::numeric_limits<int64_t>::min()) ||
+        d > static_cast<double>(std::numeric_limits<int64_t>::max())) {
+      throw std::runtime_error("param '" + param_name +
+                               "' out of int64 range");
+    }
+    return static_cast<int64_t>(d);
+  }
+  // Check unsigned integers that exceed int64_t max
+  if (value.is_number_unsigned()) {
+    uint64_t u = value.get<uint64_t>();
+    if (u > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
+      throw std::runtime_error("param '" + param_name +
+                               "' out of int64 range");
+    }
+    return static_cast<int64_t>(u);
+  }
+  return value.get<int64_t>();
+}
+
+inline double validateFloat(const nlohmann::json &value,
+                            const std::string &param_name) {
+  if (!value.is_number()) {
+    throw std::runtime_error("param '" + param_name + "' must be float");
+  }
+  double d = value.get<double>();
+  if (!std::isfinite(d)) {
+    throw std::runtime_error("param '" + param_name +
+                             "' must be finite number");
+  }
+  return d;
+}
+
+inline bool validateBool(const nlohmann::json &value,
+                         const std::string &param_name) {
+  if (!value.is_boolean()) {
+    throw std::runtime_error("param '" + param_name + "' must be bool");
+  }
+  return value.get<bool>();
+}
+
+inline std::string validateString(const nlohmann::json &value,
+                                  const std::string &param_name) {
+  if (!value.is_string()) {
+    throw std::runtime_error("param '" + param_name + "' must be string");
+  }
+  return value.get<std::string>();
+}
+
+class ParamTable {
+public:
+  // Check if param is set (either value or explicit null)
+  bool has(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    return it != values_.end() &&
+           !std::holds_alternative<std::monostate>(it->second);
+  }
+
+  // Check if param is explicitly null
+  bool isNull(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    return it != values_.end() && std::holds_alternative<NullTag>(it->second);
+  }
+
+  // Typed getters - return nullopt if unset or null
+  std::optional<int64_t> getInt(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    if (auto *val = std::get_if<int64_t>(&it->second)) {
+      return *val;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<double> getFloat(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    if (auto *val = std::get_if<double>(&it->second)) {
+      return *val;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<bool> getBool(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    if (auto *val = std::get_if<bool>(&it->second)) {
+      return *val;
+    }
+    return std::nullopt;
+  }
+
+  std::optional<std::string_view> getString(ParamId id) const {
+    auto it = values_.find(static_cast<uint32_t>(id));
+    if (it == values_.end()) {
+      return std::nullopt;
+    }
+    if (auto *val = std::get_if<std::string>(&it->second)) {
+      return *val;
+    }
+    return std::nullopt;
+  }
+
+  // Set a value
+  void set(ParamId id, ParamValue value) {
+    values_[static_cast<uint32_t>(id)] = std::move(value);
+  }
+
+  // Parse and validate param_overrides from request JSON
+  static ParamTable fromParamOverrides(const nlohmann::json &overrides) {
+    ParamTable table;
+
+    if (overrides.is_null()) {
+      return table;
+    }
+
+    if (!overrides.is_object()) {
+      throw std::runtime_error("param_overrides must be an object");
+    }
+
+    for (auto it = overrides.begin(); it != overrides.end(); ++it) {
+      const std::string &name = it.key();
+      const auto &value = it.value();
+
+      // Look up param metadata
+      const ParamMeta *meta = findParamByName(name);
+      if (!meta) {
+        throw std::runtime_error("unknown param '" + name + "'");
+      }
+
+      // Check allow_write (fail-closed)
+      if (!meta->allow_write) {
+        throw std::runtime_error("param '" + name + "' is not writable");
+      }
+
+      // Check status (fail-closed: only Active params can be overridden)
+      if (meta->status != Status::Active) {
+        throw std::runtime_error("param '" + name + "' is " +
+                                 (meta->status == Status::Deprecated
+                                      ? "deprecated"
+                                      : "blocked"));
+      }
+
+      // Handle null
+      if (value.is_null()) {
+        if (!meta->nullable) {
+          throw std::runtime_error("param '" + name + "' cannot be null");
+        }
+        table.set(static_cast<ParamId>(meta->id), NullTag{});
+        continue;
+      }
+
+      // Validate and set based on type
+      switch (meta->type) {
+      case ParamType::Int:
+        table.set(static_cast<ParamId>(meta->id), validateInt(value, name));
+        break;
+      case ParamType::Float:
+        table.set(static_cast<ParamId>(meta->id), validateFloat(value, name));
+        break;
+      case ParamType::Bool:
+        table.set(static_cast<ParamId>(meta->id), validateBool(value, name));
+        break;
+      case ParamType::String:
+        table.set(static_cast<ParamId>(meta->id), validateString(value, name));
+        break;
+      }
+    }
+
+    return table;
+  }
+
+private:
+  std::unordered_map<uint32_t, ParamValue> values_;
+};
+
+// Execution context passed to task run functions
+struct ExecCtx {
+  const ParamTable *params = nullptr;
+  // Future: request_id, engine_request_id, mode, logger, budgets...
+};
+
+} // namespace rankd

--- a/engine/include/task_registry.h
+++ b/engine/include/task_registry.h
@@ -11,6 +11,9 @@
 
 namespace rankd {
 
+// Forward declaration
+struct ExecCtx;
+
 // Param types supported in task param schemas (named TaskParamType to avoid
 // conflict with generated ParamType in param_registry.h)
 enum class TaskParamType { Int, Float, Bool, String };
@@ -74,9 +77,9 @@ struct ValidatedParams {
   }
 };
 
-// Task function signature: (inputs, validated_params) -> output
-using TaskFn =
-    std::function<RowSet(const std::vector<RowSet> &, const ValidatedParams &)>;
+// Task function signature: (inputs, validated_params, exec_ctx) -> output
+using TaskFn = std::function<RowSet(const std::vector<RowSet> &,
+                                    const ValidatedParams &, const ExecCtx &)>;
 
 // Combined task entry: spec + run function
 struct TaskEntry {
@@ -98,7 +101,7 @@ public:
 
   // Execute task with pre-validated params
   RowSet execute(const std::string &op, const std::vector<RowSet> &inputs,
-                 const ValidatedParams &params) const;
+                 const ValidatedParams &params, const ExecCtx &ctx) const;
 
   // Get all task specs (for manifest digest)
   std::vector<TaskSpec> get_all_specs() const;

--- a/engine/src/executor.cpp
+++ b/engine/src/executor.cpp
@@ -90,7 +90,7 @@ void validate_plan(const Plan &plan) {
   }
 }
 
-std::vector<RowSet> execute_plan(const Plan &plan) {
+std::vector<RowSet> execute_plan(const Plan &plan, const ExecCtx &ctx) {
   // Build node_id -> index map
   std::unordered_map<std::string, size_t> node_index;
   for (size_t i = 0; i < plan.nodes.size(); ++i) {
@@ -144,7 +144,7 @@ std::vector<RowSet> execute_plan(const Plan &plan) {
     }
 
     auto validated_params = registry.validate_params(node.op, node.params);
-    results[node_id] = registry.execute(node.op, inputs, validated_params);
+    results[node_id] = registry.execute(node.op, inputs, validated_params, ctx);
   }
 
   // Collect outputs

--- a/engine/src/task_registry.cpp
+++ b/engine/src/task_registry.cpp
@@ -1,4 +1,5 @@
 #include "task_registry.h"
+#include "param_table.h"
 #include "sha256.h"
 #include <algorithm>
 #include <cmath>
@@ -33,8 +34,8 @@ TaskRegistry::TaskRegistry() {
 
   register_task(
       std::move(viewer_follow_spec),
-      [](const std::vector<RowSet> &inputs,
-         const ValidatedParams &params) -> RowSet {
+      [](const std::vector<RowSet> &inputs, const ValidatedParams &params,
+         [[maybe_unused]] const ExecCtx &ctx) -> RowSet {
         if (!inputs.empty()) {
           throw std::runtime_error("viewer.follow: expected 0 inputs");
         }
@@ -77,8 +78,8 @@ TaskRegistry::TaskRegistry() {
 
   register_task(
       std::move(take_spec),
-      [](const std::vector<RowSet> &inputs,
-         const ValidatedParams &params) -> RowSet {
+      [](const std::vector<RowSet> &inputs, const ValidatedParams &params,
+         [[maybe_unused]] const ExecCtx &ctx) -> RowSet {
         if (inputs.size() != 1) {
           throw std::runtime_error("take: expected exactly 1 input");
         }
@@ -301,12 +302,13 @@ ValidatedParams TaskRegistry::validate_params(const std::string &op,
 
 RowSet TaskRegistry::execute(const std::string &op,
                              const std::vector<RowSet> &inputs,
-                             const ValidatedParams &params) const {
+                             const ValidatedParams &params,
+                             const ExecCtx &ctx) const {
   auto it = tasks_.find(op);
   if (it == tasks_.end()) {
     throw std::runtime_error("Unknown op: " + op);
   }
-  return it->second.run(inputs, params);
+  return it->second.run(inputs, params, ctx);
 }
 
 std::vector<TaskSpec> TaskRegistry::get_all_specs() const {

--- a/engine/tests/test_param_table.cpp
+++ b/engine/tests/test_param_table.cpp
@@ -1,0 +1,163 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_string.hpp>
+
+#include "param_table.h"
+#include <cmath>
+
+using namespace rankd;
+using Catch::Matchers::ContainsSubstring;
+
+TEST_CASE("ParamTable basic set/get operations", "[param_table]") {
+  ParamTable table;
+
+  SECTION("initially empty") {
+    REQUIRE_FALSE(table.has(ParamId::media_age_penalty_weight));
+    REQUIRE_FALSE(table.getFloat(ParamId::media_age_penalty_weight).has_value());
+  }
+
+  SECTION("set and get float") {
+    table.set(ParamId::media_age_penalty_weight, 0.5);
+    REQUIRE(table.has(ParamId::media_age_penalty_weight));
+    REQUIRE(table.getFloat(ParamId::media_age_penalty_weight).has_value());
+    REQUIRE(table.getFloat(ParamId::media_age_penalty_weight).value() == 0.5);
+    REQUIRE_FALSE(table.isNull(ParamId::media_age_penalty_weight));
+  }
+
+  SECTION("set and get string") {
+    table.set(ParamId::blocklist_regex, std::string("test.*"));
+    REQUIRE(table.has(ParamId::blocklist_regex));
+    REQUIRE(table.getString(ParamId::blocklist_regex).has_value());
+    REQUIRE(table.getString(ParamId::blocklist_regex).value() == "test.*");
+  }
+}
+
+TEST_CASE("ParamTable null value handling", "[param_table]") {
+  ParamTable table;
+
+  table.set(ParamId::blocklist_regex, NullTag{});
+
+  REQUIRE(table.has(ParamId::blocklist_regex));
+  REQUIRE(table.isNull(ParamId::blocklist_regex));
+  REQUIRE_FALSE(table.getString(ParamId::blocklist_regex).has_value());
+}
+
+TEST_CASE("ParamTable::fromParamOverrides with valid input", "[param_table]") {
+  nlohmann::json overrides;
+  overrides["media_age_penalty_weight"] = 0.35;
+  overrides["esr_cutoff"] = 2.5;
+
+  auto table = ParamTable::fromParamOverrides(overrides);
+
+  REQUIRE(table.has(ParamId::media_age_penalty_weight));
+  REQUIRE(table.getFloat(ParamId::media_age_penalty_weight).value() == 0.35);
+  REQUIRE(table.has(ParamId::esr_cutoff));
+  REQUIRE(table.getFloat(ParamId::esr_cutoff).value() == 2.5);
+}
+
+TEST_CASE("ParamTable::fromParamOverrides nullable params", "[param_table]") {
+  SECTION("null for nullable param") {
+    nlohmann::json overrides;
+    overrides["blocklist_regex"] = nullptr;
+
+    auto table = ParamTable::fromParamOverrides(overrides);
+    REQUIRE(table.has(ParamId::blocklist_regex));
+    REQUIRE(table.isNull(ParamId::blocklist_regex));
+  }
+
+  SECTION("value for nullable param") {
+    nlohmann::json overrides;
+    overrides["blocklist_regex"] = "foo.*";
+
+    auto table = ParamTable::fromParamOverrides(overrides);
+    REQUIRE(table.has(ParamId::blocklist_regex));
+    REQUIRE_FALSE(table.isNull(ParamId::blocklist_regex));
+    REQUIRE(table.getString(ParamId::blocklist_regex).value() == "foo.*");
+  }
+}
+
+TEST_CASE("ParamTable::fromParamOverrides rejects unknown param",
+          "[param_table]") {
+  nlohmann::json overrides;
+  overrides["unknown_param"] = 42;
+
+  REQUIRE_THROWS_WITH(ParamTable::fromParamOverrides(overrides),
+                      ContainsSubstring("unknown param") &&
+                          ContainsSubstring("unknown_param"));
+}
+
+TEST_CASE("ParamTable::fromParamOverrides rejects wrong type", "[param_table]") {
+  nlohmann::json overrides;
+  overrides["media_age_penalty_weight"] = "not a number";
+
+  REQUIRE_THROWS_WITH(ParamTable::fromParamOverrides(overrides),
+                      ContainsSubstring("must be float"));
+}
+
+TEST_CASE("ParamTable::fromParamOverrides rejects null for non-nullable",
+          "[param_table]") {
+  nlohmann::json overrides;
+  overrides["media_age_penalty_weight"] = nullptr;
+
+  REQUIRE_THROWS_WITH(ParamTable::fromParamOverrides(overrides),
+                      ContainsSubstring("cannot be null"));
+}
+
+TEST_CASE("ParamTable::fromParamOverrides rejects non-finite floats",
+          "[param_table]") {
+  SECTION("infinity") {
+    nlohmann::json overrides;
+    overrides["media_age_penalty_weight"] =
+        std::numeric_limits<double>::infinity();
+
+    REQUIRE_THROWS_WITH(ParamTable::fromParamOverrides(overrides),
+                        ContainsSubstring("finite"));
+  }
+
+  SECTION("NaN") {
+    nlohmann::json overrides;
+    overrides["media_age_penalty_weight"] = std::nan("");
+
+    REQUIRE_THROWS_WITH(ParamTable::fromParamOverrides(overrides),
+                        ContainsSubstring("finite"));
+  }
+}
+
+TEST_CASE("validateInt handles overflow", "[param_table]") {
+  SECTION("rejects uint64 exceeding int64 max") {
+    nlohmann::json large_uint =
+        static_cast<uint64_t>(std::numeric_limits<int64_t>::max()) + 1;
+
+    REQUIRE_THROWS_WITH(validateInt(large_uint, "test_param"),
+                        ContainsSubstring("out of int64 range"));
+  }
+
+  SECTION("accepts int64 max") {
+    nlohmann::json max_int = std::numeric_limits<int64_t>::max();
+    REQUIRE(validateInt(max_int, "test_param") ==
+            std::numeric_limits<int64_t>::max());
+  }
+
+  SECTION("accepts negative integers") {
+    nlohmann::json neg_int = -42;
+    REQUIRE(validateInt(neg_int, "test_param") == -42);
+  }
+}
+
+TEST_CASE("ParamTable::fromParamOverrides with empty/null input",
+          "[param_table]") {
+  SECTION("empty object") {
+    nlohmann::json overrides = nlohmann::json::object();
+    auto table = ParamTable::fromParamOverrides(overrides);
+
+    REQUIRE_FALSE(table.has(ParamId::media_age_penalty_weight));
+    REQUIRE_FALSE(table.has(ParamId::blocklist_regex));
+    REQUIRE_FALSE(table.has(ParamId::esr_cutoff));
+  }
+
+  SECTION("null") {
+    nlohmann::json overrides = nullptr;
+    auto table = ParamTable::fromParamOverrides(overrides);
+
+    REQUIRE_FALSE(table.has(ParamId::media_age_penalty_weight));
+  }
+}

--- a/engine/tests/test_rowset.cpp
+++ b/engine/tests/test_rowset.cpp
@@ -1,68 +1,76 @@
+#include <catch2/catch_test_macros.hpp>
+
 #include "column_batch.h"
+#include "param_table.h"
 #include "rowset.h"
 #include "task_registry.h"
-#include <cassert>
-#include <iostream>
-#include <vector>
 
 using namespace rankd;
 
-void test_viewer_follow_and_take() {
-  std::cout << "Test: viewer.follow -> take" << std::endl;
+// Empty context for tests
+static ExecCtx empty_ctx;
 
+TEST_CASE("viewer.follow creates batch with sequential ids", "[rowset][task]") {
   auto &registry = TaskRegistry::instance();
 
-  // viewer.follow with fanout=10
+  nlohmann::json params_json;
+  params_json["fanout"] = 10;
+  auto params = registry.validate_params("viewer.follow", params_json);
+  RowSet source = registry.execute("viewer.follow", {}, params, empty_ctx);
+
+  REQUIRE(source.batch->size() == 10);
+  REQUIRE_FALSE(source.selection.has_value());
+  REQUIRE_FALSE(source.order.has_value());
+
+  SECTION("ids are 1-indexed") {
+    for (size_t i = 0; i < 10; ++i) {
+      REQUIRE(source.batch->getId(i) == static_cast<int64_t>(i + 1));
+    }
+  }
+}
+
+TEST_CASE("take limits output and shares batch pointer", "[rowset][task]") {
+  auto &registry = TaskRegistry::instance();
+
+  // Create source with fanout=10
   nlohmann::json follow_params_json;
   follow_params_json["fanout"] = 10;
-  auto follow_params = registry.validate_params("viewer.follow", follow_params_json);
-  RowSet source = registry.execute("viewer.follow", {}, follow_params);
-
-  assert(source.batch->size() == 10);
-  assert(!source.selection.has_value());
-  assert(!source.order.has_value());
-
-  // Verify ids are 1..10
-  for (size_t i = 0; i < 10; ++i) {
-    assert(source.batch->getId(i) == static_cast<int64_t>(i + 1));
-  }
+  auto follow_params =
+      registry.validate_params("viewer.follow", follow_params_json);
+  RowSet source = registry.execute("viewer.follow", {}, follow_params, empty_ctx);
 
   // take with count=5
   nlohmann::json take_params_json;
   take_params_json["count"] = 5;
   auto take_params = registry.validate_params("take", take_params_json);
-  RowSet result = registry.execute("take", {source}, take_params);
+  RowSet result = registry.execute("take", {source}, take_params, empty_ctx);
 
-  // Same batch pointer (no copy)
-  assert(result.batch.get() == source.batch.get());
-
-  // Selection should be [0,1,2,3,4]
-  assert(result.selection.has_value());
-  assert(result.selection->size() == 5);
-
-  // Get output ids
-  auto indices = result.materializeIndexViewForOutput(result.batch->size());
-  assert(indices.size() == 5);
-
-  std::vector<int64_t> output_ids;
-  for (uint32_t idx : indices) {
-    output_ids.push_back(result.batch->getId(idx));
+  SECTION("shares batch pointer (no copy)") {
+    REQUIRE(result.batch.get() == source.batch.get());
   }
 
-  std::vector<int64_t> expected_ids = {1, 2, 3, 4, 5};
-  assert(output_ids == expected_ids);
+  SECTION("creates selection of first 5 elements") {
+    REQUIRE(result.selection.has_value());
+    REQUIRE(result.selection->size() == 5);
+  }
 
-  // Materialize count must be 0
-  assert(result.batch->debug()->materialize_count == 0);
+  SECTION("output ids are [1,2,3,4,5]") {
+    auto indices = result.materializeIndexViewForOutput(result.batch->size());
+    REQUIRE(indices.size() == 5);
 
-  std::cout << "  PASS: output ids are [1,2,3,4,5]" << std::endl;
-  std::cout << "  PASS: same batch pointer" << std::endl;
-  std::cout << "  PASS: materialize_count == 0" << std::endl;
+    std::vector<int64_t> output_ids;
+    for (uint32_t idx : indices) {
+      output_ids.push_back(result.batch->getId(idx));
+    }
+    REQUIRE(output_ids == std::vector<int64_t>{1, 2, 3, 4, 5});
+  }
+
+  SECTION("materialize_count stays at 0") {
+    REQUIRE(result.batch->debug()->materialize_count == 0);
+  }
 }
 
-void test_selection_and_order_combined() {
-  std::cout << "Test: selection + order combined iteration" << std::endl;
-
+TEST_CASE("RowSet iteration with selection and order", "[rowset]") {
   // Create batch with size=6, ids = [10, 20, 30, 40, 50, 60]
   auto debug = std::make_shared<DebugCounters>();
   auto batch = std::make_shared<ColumnBatch>(6, debug);
@@ -70,74 +78,55 @@ void test_selection_and_order_combined() {
     batch->setId(i, static_cast<int64_t>((i + 1) * 10));
   }
 
-  // selection = [0, 2, 3, 5] (indices 1 and 4 are filtered out)
-  // order = [5, 4, 3, 2, 1, 0] (reverse order)
-  // Expected iteration: order filtered by selection -> [5, 3, 2, 0]
-  RowSet rs;
-  rs.batch = batch;
-  rs.selection = std::vector<uint32_t>{0, 2, 3, 5};
-  rs.order = std::vector<uint32_t>{5, 4, 3, 2, 1, 0};
+  SECTION("order + selection filters correctly") {
+    // selection = [0, 2, 3, 5] (indices 1 and 4 are filtered out)
+    // order = [5, 4, 3, 2, 1, 0] (reverse order)
+    // Expected iteration: order filtered by selection -> [5, 3, 2, 0]
+    RowSet rs;
+    rs.batch = batch;
+    rs.selection = std::vector<uint32_t>{0, 2, 3, 5};
+    rs.order = std::vector<uint32_t>{5, 4, 3, 2, 1, 0};
 
-  auto indices = rs.materializeIndexViewForOutput(batch->size());
+    auto indices = rs.materializeIndexViewForOutput(batch->size());
 
-  std::vector<uint32_t> expected_indices = {5, 3, 2, 0};
-  assert(indices == expected_indices);
+    REQUIRE(indices == std::vector<uint32_t>{5, 3, 2, 0});
 
-  // Verify the ids at those indices
-  std::vector<int64_t> output_ids;
-  for (uint32_t idx : indices) {
-    output_ids.push_back(batch->getId(idx));
-  }
-  std::vector<int64_t> expected_ids = {60, 40, 30, 10};
-  assert(output_ids == expected_ids);
-
-  assert(debug->materialize_count == 0);
-
-  std::cout << "  PASS: iteration yields indices [5,3,2,0]" << std::endl;
-  std::cout << "  PASS: output ids are [60,40,30,10]" << std::endl;
-  std::cout << "  PASS: materialize_count == 0" << std::endl;
-}
-
-void test_order_only() {
-  std::cout << "Test: order only iteration" << std::endl;
-
-  auto batch = std::make_shared<ColumnBatch>(4);
-  for (size_t i = 0; i < 4; ++i) {
-    batch->setId(i, static_cast<int64_t>(i + 1));
+    std::vector<int64_t> output_ids;
+    for (uint32_t idx : indices) {
+      output_ids.push_back(batch->getId(idx));
+    }
+    REQUIRE(output_ids == std::vector<int64_t>{60, 40, 30, 10});
+    REQUIRE(debug->materialize_count == 0);
   }
 
-  RowSet rs;
-  rs.batch = batch;
-  rs.order = std::vector<uint32_t>{3, 1, 2, 0};
+  SECTION("order only") {
+    RowSet rs;
+    rs.batch = batch;
+    rs.order = std::vector<uint32_t>{5, 3, 1, 4, 2, 0};
 
-  auto indices = rs.materializeIndexViewForOutput(batch->size());
-  std::vector<uint32_t> expected = {3, 1, 2, 0};
-  assert(indices == expected);
-
-  std::cout << "  PASS: order-only iteration works" << std::endl;
-}
-
-void test_no_selection_no_order() {
-  std::cout << "Test: no selection, no order" << std::endl;
-
-  auto batch = std::make_shared<ColumnBatch>(3);
-  for (size_t i = 0; i < 3; ++i) {
-    batch->setId(i, static_cast<int64_t>(i + 100));
+    auto indices = rs.materializeIndexViewForOutput(batch->size());
+    REQUIRE(indices == std::vector<uint32_t>{5, 3, 1, 4, 2, 0});
   }
 
-  RowSet rs;
-  rs.batch = batch;
+  SECTION("selection only") {
+    RowSet rs;
+    rs.batch = batch;
+    rs.selection = std::vector<uint32_t>{1, 3, 5};
 
-  auto indices = rs.materializeIndexViewForOutput(batch->size());
-  std::vector<uint32_t> expected = {0, 1, 2};
-  assert(indices == expected);
+    auto indices = rs.materializeIndexViewForOutput(batch->size());
+    REQUIRE(indices == std::vector<uint32_t>{1, 3, 5});
+  }
 
-  std::cout << "  PASS: default iteration [0..N) works" << std::endl;
+  SECTION("no selection, no order defaults to [0..N)") {
+    RowSet rs;
+    rs.batch = batch;
+
+    auto indices = rs.materializeIndexViewForOutput(batch->size());
+    REQUIRE(indices == std::vector<uint32_t>{0, 1, 2, 3, 4, 5});
+  }
 }
 
-void test_take_with_selection_and_order() {
-  std::cout << "Test: take with both selection and order" << std::endl;
-
+TEST_CASE("take with selection and order combined", "[rowset][task]") {
   auto &registry = TaskRegistry::instance();
 
   // Create batch with ids [10, 20, 30, 40]
@@ -154,47 +143,27 @@ void test_take_with_selection_and_order() {
   input.selection = std::vector<uint32_t>{0, 2};
   input.order = std::vector<uint32_t>{3, 2, 1, 0};
 
-  // take(1) should give first row in iteration order = index 2 (id=30)
-  nlohmann::json take_params_json;
-  take_params_json["count"] = 1;
-  auto take_params = registry.validate_params("take", take_params_json);
-  RowSet result = registry.execute("take", {input}, take_params);
+  SECTION("take(1) yields first in iteration order") {
+    nlohmann::json take_params_json;
+    take_params_json["count"] = 1;
+    auto take_params = registry.validate_params("take", take_params_json);
+    RowSet result = registry.execute("take", {input}, take_params, empty_ctx);
 
-  // Same batch pointer
-  assert(result.batch.get() == input.batch.get());
+    REQUIRE(result.batch.get() == input.batch.get());
 
-  auto indices = result.materializeIndexViewForOutput(result.batch->size());
-  assert(indices.size() == 1);
-  assert(indices[0] == 2);
-  assert(result.batch->getId(indices[0]) == 30);
+    auto indices = result.materializeIndexViewForOutput(result.batch->size());
+    REQUIRE(indices.size() == 1);
+    REQUIRE(indices[0] == 2);
+    REQUIRE(result.batch->getId(indices[0]) == 30);
+  }
 
-  std::cout << "  PASS: take(1) with selection+order yields index 2 (id=30)"
-            << std::endl;
+  SECTION("take(2) yields both in iteration order") {
+    nlohmann::json take_params_json;
+    take_params_json["count"] = 2;
+    auto take_params = registry.validate_params("take", take_params_json);
+    RowSet result = registry.execute("take", {input}, take_params, empty_ctx);
 
-  // take(2) should give both rows in iteration order = [2, 0]
-  nlohmann::json take_params2_json;
-  take_params2_json["count"] = 2;
-  auto take_params2 = registry.validate_params("take", take_params2_json);
-  RowSet result2 = registry.execute("take", {input}, take_params2);
-
-  auto indices2 = result2.materializeIndexViewForOutput(result2.batch->size());
-  assert(indices2.size() == 2);
-  std::vector<uint32_t> expected = {2, 0};
-  assert(indices2 == expected);
-
-  std::cout << "  PASS: take(2) with selection+order yields [2, 0]"
-            << std::endl;
-}
-
-int main() {
-  std::cout << "=== RowSet Tests ===" << std::endl;
-
-  test_viewer_follow_and_take();
-  test_selection_and_order_combined();
-  test_order_only();
-  test_no_selection_no_order();
-  test_take_with_selection_and_order();
-
-  std::cout << std::endl << "All tests passed!" << std::endl;
-  return 0;
+    auto indices = result.materializeIndexViewForOutput(result.batch->size());
+    REQUIRE(indices == std::vector<uint32_t>{2, 0});
+  }
 }


### PR DESCRIPTION
## Summary
- Add `ParamTable` class for runtime parameter storage with typed getters (int, float, bool, string)
- Implement request-level `param_overrides` validation against generated registry metadata
- Wire `ExecCtx` through executor and task registry for future context plumbing

## Changes
- `engine/include/param_table.h` - ParamTable class, validation helpers, ExecCtx struct
- `engine/include/executor.h` / `executor.cpp` - Accept ExecCtx parameter
- `engine/include/task_registry.h` / `task_registry.cpp` - Pass ExecCtx to task functions
- `engine/src/main.cpp` - Parse param_overrides, build ParamTable, create ExecCtx
- `engine/tests/test_param_table.cpp` - Unit tests (11 tests)
- `engine/tests/test_rowset.cpp` - Updated to pass ExecCtx
- `scripts/ci.sh` - Added 5 new integration tests for param_overrides

## Validation Features
- Unknown params rejected (fail-closed)
- Wrong types rejected
- Non-finite floats (Inf, NaN) rejected
- Nullable param handling per registry metadata

## Test plan
- [x] All existing unit tests pass
- [x] New ParamTable unit tests pass (11 tests)
- [x] CI integration tests pass (tests 12-16 for param_overrides)
- [x] `./scripts/ci.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)