### PR TITLE
Step 05b: vm task and expression evaluation

### DIFF
--- a/artifacts/plans/demo.plan.json
+++ b/artifacts/plans/demo.plan.json
@@ -3,7 +3,19 @@
   "plan_name": "demo",
   "nodes": [
     { "node_id": "n0", "op": "viewer.follow", "inputs": [], "params": { "fanout": 10, "trace": "src" } },
-    { "node_id": "n1", "op": "take", "inputs": ["n0"], "params": { "count": 5, "trace": "take" } }
+    { "node_id": "n1", "op": "vm", "inputs": ["n0"], "params": { "out_key": 2001, "expr_id": "e0", "trace": "vm_final" } },
+    { "node_id": "n2", "op": "take", "inputs": ["n1"], "params": { "count": 5, "trace": "take" } }
   ],
-  "outputs": ["n1"]
+  "outputs": ["n2"],
+  "expr_table": {
+    "e0": {
+      "op": "mul",
+      "a": { "op": "key_ref", "key_id": 1 },
+      "b": {
+        "op": "coalesce",
+        "a": { "op": "param_ref", "param_id": 1 },
+        "b": { "op": "const_number", "value": 0.2 }
+      }
+    }
+  }
 }

--- a/engine/include/column_batch.h
+++ b/engine/include/column_batch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include <memory>
 #include <vector>
 
@@ -10,32 +11,92 @@ struct DebugCounters {
   uint64_t materialize_count = 0;
 };
 
+// Float column storage: values + validity bitmap
+struct FloatColumn {
+  std::vector<double> values;
+  std::vector<uint8_t> valid;
+
+  explicit FloatColumn(size_t n) : values(n, 0.0), valid(n, 0) {}
+};
+
+// Shared id column storage (allows sharing without copy)
+struct IdColumn {
+  std::vector<int64_t> values;
+  std::vector<uint8_t> valid;
+
+  explicit IdColumn(size_t n) : values(n), valid(n, 1) {}
+};
+
 class ColumnBatch {
 public:
   explicit ColumnBatch(size_t num_rows,
                        std::shared_ptr<DebugCounters> debug = nullptr)
-      : id_values_(num_rows), id_valid_(num_rows, 1),
+      : id_col_(std::make_shared<IdColumn>(num_rows)),
         debug_(debug ? debug : std::make_shared<DebugCounters>()) {}
 
-  size_t size() const { return id_values_.size(); }
+  size_t size() const { return id_col_->values.size(); }
 
-  int64_t getId(size_t row_index) const { return id_values_[row_index]; }
+  int64_t getId(size_t row_index) const { return id_col_->values[row_index]; }
 
-  void setId(size_t row_index, int64_t value) { id_values_[row_index] = value; }
+  void setId(size_t row_index, int64_t value) {
+    id_col_->values[row_index] = value;
+  }
 
-  bool isIdValid(size_t row_index) const { return id_valid_[row_index] != 0; }
+  bool isIdValid(size_t row_index) const {
+    return id_col_->valid[row_index] != 0;
+  }
 
   const std::shared_ptr<DebugCounters> &debug() const { return debug_; }
 
   // Copy id column - increments materialize_count
   std::vector<int64_t> copyIdColumn() const {
     debug_->materialize_count++;
-    return id_values_;
+    return id_col_->values;
+  }
+
+  // Float column accessors
+  bool hasFloat(uint32_t key_id) const {
+    return float_cols_.find(key_id) != float_cols_.end();
+  }
+
+  const FloatColumn *getFloatCol(uint32_t key_id) const {
+    auto it = float_cols_.find(key_id);
+    if (it == float_cols_.end()) {
+      return nullptr;
+    }
+    return it->second.get();
+  }
+
+  // Returns a NEW ColumnBatch that shares the same id storage and existing
+  // float columns, but adds/replaces the specified float column.
+  // Does NOT increment materialize_count (no id copy).
+  ColumnBatch withFloatColumn(uint32_t key_id,
+                              std::shared_ptr<const FloatColumn> col) const {
+    ColumnBatch result;
+    result.id_col_ = id_col_;          // Share id storage
+    result.float_cols_ = float_cols_;  // Copy map (shared_ptr copies are cheap)
+    result.debug_ = debug_;            // Share debug counters
+    result.float_cols_[key_id] = std::move(col);
+    return result;
+  }
+
+  // Get all float column key_ids in ascending order (for deterministic output)
+  std::vector<uint32_t> getFloatKeyIds() const {
+    std::vector<uint32_t> keys;
+    keys.reserve(float_cols_.size());
+    for (const auto &[key_id, col] : float_cols_) {
+      keys.push_back(key_id);
+    }
+    return keys;
   }
 
 private:
-  std::vector<int64_t> id_values_;
-  std::vector<uint8_t> id_valid_;
+  // Private default constructor for withFloatColumn
+  ColumnBatch() = default;
+
+  std::shared_ptr<IdColumn> id_col_;
+  std::map<uint32_t, std::shared_ptr<const FloatColumn>>
+      float_cols_; // key_id -> column
   std::shared_ptr<DebugCounters> debug_;
 };
 

--- a/engine/include/expr_eval.h
+++ b/engine/include/expr_eval.h
@@ -1,0 +1,135 @@
+#pragma once
+
+#include "column_batch.h"
+#include "key_registry.h"
+#include "param_table.h"
+#include "plan.h"
+#include <cmath>
+#include <optional>
+#include <stdexcept>
+
+namespace rankd {
+
+// Lookup KeyMeta by key_id (linear scan, OK for small registry)
+inline const KeyMeta *findKeyById(uint32_t key_id) {
+  for (const auto &meta : kKeyRegistry) {
+    if (meta.id == key_id) {
+      return &meta;
+    }
+  }
+  return nullptr;
+}
+
+// Expression evaluation result: nullopt = null, otherwise numeric value
+using ExprResult = std::optional<double>;
+
+// Evaluate an expression node for a specific row
+// Returns nullopt for null, double for numeric result
+// Throws on non-finite result
+inline ExprResult eval_expr(const ExprNode &node, size_t row,
+                            const ColumnBatch &batch, const ExecCtx &ctx) {
+  if (node.op == "const_number") {
+    return node.const_value;
+  }
+
+  if (node.op == "const_null") {
+    return std::nullopt;
+  }
+
+  if (node.op == "key_ref") {
+    // Special case: Key.id (key_id=1)
+    if (node.key_id == 1) {
+      if (!batch.isIdValid(row)) {
+        return std::nullopt;
+      }
+      return static_cast<double>(batch.getId(row));
+    }
+
+    // Float column lookup
+    const FloatColumn *col = batch.getFloatCol(node.key_id);
+    if (!col || col->valid[row] == 0) {
+      return std::nullopt;
+    }
+    return col->values[row];
+  }
+
+  if (node.op == "param_ref") {
+    if (!ctx.params) {
+      return std::nullopt;
+    }
+
+    // Look up param metadata
+    const ParamMeta *meta = nullptr;
+    for (const auto &m : kParamRegistry) {
+      if (m.id == node.param_id) {
+        meta = &m;
+        break;
+      }
+    }
+    if (!meta) {
+      return std::nullopt;
+    }
+
+    ParamId pid = static_cast<ParamId>(node.param_id);
+    if (!ctx.params->has(pid)) {
+      return std::nullopt;
+    }
+    if (ctx.params->isNull(pid)) {
+      return std::nullopt;
+    }
+
+    // Get value based on type
+    if (meta->type == ParamType::Int) {
+      auto val = ctx.params->getInt(pid);
+      if (val) {
+        return static_cast<double>(*val);
+      }
+    } else if (meta->type == ParamType::Float) {
+      auto val = ctx.params->getFloat(pid);
+      if (val) {
+        return *val;
+      }
+    }
+    return std::nullopt;
+  }
+
+  if (node.op == "add" || node.op == "sub" || node.op == "mul") {
+    auto a_result = eval_expr(*node.a, row, batch, ctx);
+    auto b_result = eval_expr(*node.b, row, batch, ctx);
+
+    // Null propagation
+    if (!a_result || !b_result) {
+      return std::nullopt;
+    }
+
+    double result;
+    if (node.op == "add") {
+      result = *a_result + *b_result;
+    } else if (node.op == "sub") {
+      result = *a_result - *b_result;
+    } else {
+      result = *a_result * *b_result;
+    }
+    return result;
+  }
+
+  if (node.op == "neg") {
+    auto x_result = eval_expr(*node.a, row, batch, ctx);
+    if (!x_result) {
+      return std::nullopt;
+    }
+    return -(*x_result);
+  }
+
+  if (node.op == "coalesce") {
+    auto a_result = eval_expr(*node.a, row, batch, ctx);
+    if (a_result) {
+      return a_result;
+    }
+    return eval_expr(*node.b, row, batch, ctx);
+  }
+
+  throw std::runtime_error("Unknown expr op: " + node.op);
+}
+
+} // namespace rankd

--- a/engine/include/param_table.h
+++ b/engine/include/param_table.h
@@ -225,9 +225,14 @@ private:
   std::unordered_map<uint32_t, ParamValue> values_;
 };
 
+// Forward declaration for expr_table
+struct ExprNode;
+using ExprNodePtr = std::shared_ptr<ExprNode>;
+
 // Execution context passed to task run functions
 struct ExecCtx {
   const ParamTable *params = nullptr;
+  const std::unordered_map<std::string, ExprNodePtr> *expr_table = nullptr;
   // Future: request_id, engine_request_id, mode, logger, budgets...
 };
 

--- a/engine/include/plan.h
+++ b/engine/include/plan.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
+#include <variant>
 #include <vector>
 
 namespace rankd {
@@ -14,11 +16,40 @@ struct Node {
   nlohmann::json params;
 };
 
+// ExprNode: recursive expression tree
+struct ExprNode;
+using ExprNodePtr = std::shared_ptr<ExprNode>;
+
+struct ExprNode {
+  std::string op; // const_number, const_null, key_ref, param_ref, add, sub, mul,
+                  // neg, coalesce
+
+  // For const_number
+  double const_value = 0.0;
+
+  // For key_ref
+  uint32_t key_id = 0;
+
+  // For param_ref
+  uint32_t param_id = 0;
+
+  // For binary ops (add, sub, mul, coalesce): a, b
+  // For unary ops (neg): x stored in 'a'
+  ExprNodePtr a;
+  ExprNodePtr b;
+};
+
+// Parse ExprNode from JSON. Throws on invalid structure.
+ExprNodePtr parse_expr_node(const nlohmann::json &j);
+
 struct Plan {
   int schema_version = 0;
   std::string plan_name;
   std::vector<Node> nodes;
   std::vector<std::string> outputs;
+
+  // expr_table: expr_id -> ExprNode tree
+  std::unordered_map<std::string, ExprNodePtr> expr_table;
 };
 
 // Parse plan from JSON file. Throws std::runtime_error on parse failure.

--- a/engine/src/task_registry.cpp
+++ b/engine/src/task_registry.cpp
@@ -1,4 +1,5 @@
 #include "task_registry.h"
+#include "expr_eval.h"
 #include "param_table.h"
 #include "sha256.h"
 #include <algorithm>
@@ -140,6 +141,137 @@ TaskRegistry::TaskRegistry() {
         }
 
         return result;
+      });
+
+  // Register vm
+  TaskSpec vm_spec{
+      .op = "vm",
+      .params_schema =
+          {
+              {.name = "out_key", .type = TaskParamType::Int, .required = true},
+              {.name = "expr_id",
+               .type = TaskParamType::String,
+               .required = true},
+              {.name = "trace",
+               .type = TaskParamType::String,
+               .required = false,
+               .nullable = true},
+          },
+      .reads = {},
+      .writes = {}, // Dynamic based on out_key, but left empty for manifest
+      .default_budget = {.timeout_ms = 50},
+  };
+
+  register_task(
+      std::move(vm_spec),
+      [](const std::vector<RowSet> &inputs, const ValidatedParams &params,
+         const ExecCtx &ctx) -> RowSet {
+        if (inputs.size() != 1) {
+          throw std::runtime_error("vm: expected exactly 1 input");
+        }
+
+        int64_t out_key_raw = params.get_int("out_key");
+        if (out_key_raw <= 0) {
+          throw std::runtime_error("vm: 'out_key' must be > 0");
+        }
+        uint32_t out_key = static_cast<uint32_t>(out_key_raw);
+
+        const std::string &expr_id = params.get_string("expr_id");
+        if (expr_id.empty()) {
+          throw std::runtime_error("vm: 'expr_id' must be non-empty");
+        }
+
+        // Validate out_key exists in key registry
+        const KeyMeta *key_meta = findKeyById(out_key);
+        if (!key_meta) {
+          throw std::runtime_error("vm: out_key " + std::to_string(out_key) +
+                                   " not in key registry");
+        }
+
+        // out_key must NOT be Key.id (key_id=1)
+        if (out_key == 1) {
+          throw std::runtime_error("vm: cannot write to Key.id");
+        }
+
+        // out_key must have allow_write=true
+        if (!key_meta->allow_write) {
+          throw std::runtime_error("vm: key '" + std::string(key_meta->name) +
+                                   "' is not writable");
+        }
+
+        // out_key type must be float for this step
+        if (key_meta->type != KeyType::Float) {
+          throw std::runtime_error("vm: out_key must be Float type");
+        }
+
+        // expr_id must exist in expr_table
+        if (!ctx.expr_table) {
+          throw std::runtime_error("vm: no expr_table in context");
+        }
+        auto expr_it = ctx.expr_table->find(expr_id);
+        if (expr_it == ctx.expr_table->end()) {
+          throw std::runtime_error("vm: expr_id '" + expr_id +
+                                   "' not found in expr_table");
+        }
+        const ExprNode &expr = *expr_it->second;
+
+        const auto &input = inputs[0];
+        size_t n = input.batch->size();
+
+        // Build active set from selection
+        std::vector<uint8_t> active(n, 0);
+        if (input.selection) {
+          for (uint32_t idx : *input.selection) {
+            active[idx] = 1;
+          }
+        } else {
+          // All rows active
+          for (size_t i = 0; i < n; ++i) {
+            active[i] = 1;
+          }
+        }
+
+        // Create new float column
+        auto col = std::make_shared<FloatColumn>(n);
+
+        // Evaluate expression for each active row
+        bool has_null_active = false;
+        for (size_t row = 0; row < n; ++row) {
+          if (!active[row]) {
+            continue;
+          }
+
+          ExprResult result = eval_expr(expr, row, *input.batch, ctx);
+
+          if (!result) {
+            has_null_active = true;
+            // valid stays 0
+          } else {
+            double val = *result;
+            // Check for non-finite
+            if (!std::isfinite(val)) {
+              throw std::runtime_error(
+                  "vm: expression produced non-finite value at row " +
+                  std::to_string(row));
+            }
+            col->values[row] = val;
+            col->valid[row] = 1;
+          }
+        }
+
+        // If out_key is not nullable and any active row is null => error
+        if (!key_meta->nullable && has_null_active) {
+          throw std::runtime_error("vm: null result for non-nullable key '" +
+                                   std::string(key_meta->name) + "'");
+        }
+
+        // Create new batch with the float column
+        auto new_batch = std::make_shared<ColumnBatch>(
+            input.batch->withFloatColumn(out_key, col));
+
+        return RowSet{.batch = new_batch,
+                      .selection = input.selection,
+                      .order = input.order};
       });
 }
 

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -65,7 +65,14 @@ assert len(r['candidates']) == 5, f'expected 5 candidates, got {len(r[\"candidat
 expected_ids = [1, 2, 3, 4, 5]
 actual_ids = [c['id'] for c in r['candidates']]
 assert actual_ids == expected_ids, f'expected ids {expected_ids}, got {actual_ids}'
-print('PASS: Demo plan executed correctly')
+# Verify final_score values (id * 0.2 default)
+expected_scores = [0.2, 0.4, 0.6, 0.8, 1.0]
+for i, c in enumerate(r['candidates']):
+    assert 'final_score' in c['fields'], f'candidate {i+1} missing final_score'
+    actual = c['fields']['final_score']
+    expected = expected_scores[i]
+    assert abs(actual - expected) < 0.0001, f'candidate {i+1} final_score: expected {expected}, got {actual}'
+print('PASS: Demo plan executed correctly with final_score')
 "
 
 echo ""
@@ -101,7 +108,7 @@ assert 'task_manifest_digest' in r, 'missing task_manifest_digest'
 assert r['num_keys'] == 8, f'expected 8 keys, got {r[\"num_keys\"]}'
 assert r['num_params'] == 3, f'expected 3 params, got {r[\"num_params\"]}'
 assert r['num_features'] == 2, f'expected 2 features, got {r[\"num_features\"]}'
-assert r['num_tasks'] == 2, f'expected 2 tasks, got {r[\"num_tasks\"]}'
+assert r['num_tasks'] == 3, f'expected 3 tasks, got {r[\"num_tasks\"]}'
 print('PASS: Registry info correct')
 "
 
@@ -173,7 +180,14 @@ import sys, json
 r = json.load(sys.stdin)
 assert r['request_id'] == 'param-test', 'request_id mismatch'
 assert len(r['candidates']) == 5, f'expected 5 candidates, got {len(r[\"candidates\"])}'
-print('PASS: Valid param_overrides accepted')
+# Verify final_score values (id * 0.5 from override)
+expected_scores = [0.5, 1.0, 1.5, 2.0, 2.5]
+for i, c in enumerate(r['candidates']):
+    assert 'final_score' in c['fields'], f'candidate {i+1} missing final_score'
+    actual = c['fields']['final_score']
+    expected = expected_scores[i]
+    assert abs(actual - expected) < 0.0001, f'candidate {i+1} final_score: expected {expected}, got {actual}'
+print('PASS: Valid param_overrides with correct final_score')
 "
 
 echo ""


### PR DESCRIPTION
## Summary
- Add ExprIR support to plan artifacts with `expr_table` containing recursive `ExprNode` structures
- Implement `vm` task that evaluates expressions per row and writes float columns to `ColumnBatch`
- Refactor `ColumnBatch` to use `shared_ptr` for id storage (avoids copy when adding columns)

## Changes
- **engine/include/plan.h** - Add `ExprNode` struct and `expr_table` to `Plan`
- **engine/src/plan.cpp** - Add `parse_expr_node()` for recursive expression parsing
- **engine/include/column_batch.h** - Refactor for shared id storage + `FloatColumn` support
- **engine/include/expr_eval.h** - New file for expression evaluation with null propagation
- **engine/include/param_table.h** - Extend `ExecCtx` with `expr_table` pointer
- **engine/src/task_registry.cpp** - Add `vm` task (validates out_key, evaluates expr, writes float column)
- **engine/src/main.cpp** - Pass `expr_table` to context, output float columns in response
- **artifacts/plans/demo.plan.json** - Add vm node computing `id * coalesce(P.media_age_penalty_weight, 0.2)`
- **scripts/ci.sh** - Verify final_score values in tests

## Test plan
- [x] CI passes (all 16 tests)
- [x] Test 2: final_score = [0.2, 0.4, 0.6, 0.8, 1.0] with default weight
- [x] Test 12: final_score = [0.5, 1.0, 1.5, 2.0, 2.5] with override 0.5
- [x] Test 5: num_tasks = 3 (viewer.follow, take, vm)
- [x] Unit tests pass (63 assertions in 14 test cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)