### PR TITLE
Step 06.5: RowSet encapsulation

### DIFF
--- a/engine/include/rowset.h
+++ b/engine/include/rowset.h
@@ -4,81 +4,195 @@
 #include <algorithm>
 #include <memory>
 #include <optional>
+#include <type_traits>
 #include <vector>
 
 namespace rankd {
 
-struct RowSet {
-  std::shared_ptr<const ColumnBatch> batch;
-  std::optional<std::vector<uint32_t>> selection;
-  std::optional<std::vector<uint32_t>> order;
+// Type aliases for clarity
+using RowIndex = uint32_t;
+using SelectionVector = std::vector<RowIndex>;
+using Permutation = std::vector<RowIndex>;
 
-  // Returns up to `limit` row indices in iteration order.
-  // Does NOT copy columns - only indices.
-  std::vector<uint32_t> materializeIndexViewForOutput(size_t limit) const {
-    std::vector<uint32_t> result;
-    result.reserve(std::min(limit, batch->size()));
+// Forward declaration
+class RowSet;
 
-    if (order && selection) {
+// View class for iterating over active rows in a RowSet
+// Does not own any data - lifetime must not exceed the RowSet it references
+class ActiveRows {
+public:
+  ActiveRows(const ColumnBatch *batch,
+             const std::optional<SelectionVector> *selection,
+             const std::optional<Permutation> *order)
+      : batch_(batch), selection_(selection), order_(order) {}
+
+  // Iterate over active row indices, calling fn(RowIndex) for each.
+  // If fn returns false, iteration stops early. If fn returns void, iteration continues.
+  template <typename Fn> void forEachIndex(Fn &&fn) const {
+    // Helper to handle both void and bool return types
+    auto call_fn = [&](RowIndex idx) -> bool {
+      if constexpr (std::is_same_v<decltype(fn(idx)), void>) {
+        fn(idx);
+        return true; // continue
+      } else {
+        return fn(idx); // return value controls continuation
+      }
+    };
+
+    if (*order_ && *selection_) {
       // Both exist: iterate order, filter by selection membership
-      std::vector<uint8_t> in_selection(batch->size(), 0);
-      for (uint32_t idx : *selection) {
+      std::vector<uint8_t> in_selection(batch_->size(), 0);
+      for (RowIndex idx : **selection_) {
         in_selection[idx] = 1;
       }
-      for (uint32_t idx : *order) {
+      for (RowIndex idx : **order_) {
         if (in_selection[idx]) {
-          result.push_back(idx);
-          if (result.size() >= limit)
-            break;
+          if (!call_fn(idx))
+            return;
         }
       }
-    } else if (order) {
+    } else if (*order_) {
       // Only order exists
-      for (uint32_t idx : *order) {
-        result.push_back(idx);
-        if (result.size() >= limit)
-          break;
+      for (RowIndex idx : **order_) {
+        if (!call_fn(idx))
+          return;
       }
-    } else if (selection) {
+    } else if (*selection_) {
       // Only selection exists
-      for (uint32_t idx : *selection) {
-        result.push_back(idx);
-        if (result.size() >= limit)
-          break;
+      for (RowIndex idx : **selection_) {
+        if (!call_fn(idx))
+          return;
       }
     } else {
       // Neither: iterate [0..size)
-      size_t n = std::min(limit, batch->size());
-      for (size_t i = 0; i < n; ++i) {
-        result.push_back(static_cast<uint32_t>(i));
+      for (size_t i = 0; i < batch_->size(); ++i) {
+        if (!call_fn(static_cast<RowIndex>(i)))
+          return;
       }
     }
+  }
+
+  // Get up to `limit` row indices as a vector
+  std::vector<RowIndex> toVector(size_t limit) const {
+    std::vector<RowIndex> result;
+    result.reserve(std::min(limit, batch_->size()));
+
+    forEachIndex([&](RowIndex idx) -> bool {
+      result.push_back(idx);
+      return result.size() < limit; // false stops iteration
+    });
 
     return result;
   }
 
-  // Returns the logical size (number of active rows)
-  size_t logicalSize() const {
-    if (order && selection) {
+  // Get the number of active rows
+  size_t size() const {
+    if (*order_ && *selection_) {
       // Count how many order entries are in selection
-      std::vector<uint8_t> in_selection(batch->size(), 0);
-      for (uint32_t idx : *selection) {
+      std::vector<uint8_t> in_selection(batch_->size(), 0);
+      for (RowIndex idx : **selection_) {
         in_selection[idx] = 1;
       }
       size_t count = 0;
-      for (uint32_t idx : *order) {
+      for (RowIndex idx : **order_) {
         if (in_selection[idx])
           count++;
       }
       return count;
-    } else if (order) {
-      return order->size();
-    } else if (selection) {
-      return selection->size();
+    } else if (*order_) {
+      return (*order_)->size();
+    } else if (*selection_) {
+      return (*selection_)->size();
     } else {
-      return batch->size();
+      return batch_->size();
     }
   }
+
+private:
+  const ColumnBatch *batch_;
+  const std::optional<SelectionVector> *selection_;
+  const std::optional<Permutation> *order_;
+};
+
+// RowSet: a view over a ColumnBatch with optional selection and ordering
+// Selection = which rows are active (filtered set)
+// Order = iteration order (permutation)
+class RowSet {
+public:
+  // Construct with just a batch (all rows active, natural order)
+  explicit RowSet(std::shared_ptr<const ColumnBatch> batch)
+      : batch_(std::move(batch)), selection_(std::nullopt), order_(std::nullopt) {
+  }
+
+  // Access the underlying batch (read-only)
+  const ColumnBatch &batch() const { return *batch_; }
+
+  // Get shared pointer to batch (for sharing between RowSets)
+  std::shared_ptr<const ColumnBatch> batchPtr() const { return batch_; }
+
+  // Get a view for iterating over active rows
+  ActiveRows activeRows() const { return ActiveRows(batch_.get(), &selection_, &order_); }
+
+  // Returns up to `limit` row indices in iteration order (convenience wrapper)
+  std::vector<RowIndex> materializeIndexViewForOutput(size_t limit) const {
+    return activeRows().toVector(limit);
+  }
+
+  // Returns the logical size (number of active rows)
+  size_t logicalSize() const { return activeRows().size(); }
+
+  // Builder: create new RowSet with a different batch
+  RowSet withBatch(std::shared_ptr<const ColumnBatch> newBatch) const {
+    RowSet result(std::move(newBatch));
+    result.selection_ = selection_;
+    result.order_ = order_;
+    return result;
+  }
+
+  // Builder: create new RowSet with a selection vector
+  RowSet withSelection(SelectionVector sel) const {
+    RowSet result(batch_);
+    result.selection_ = std::move(sel);
+    result.order_ = order_;
+    return result;
+  }
+
+  // Builder: create new RowSet with a selection, clearing order
+  RowSet withSelectionClearOrder(SelectionVector sel) const {
+    RowSet result(batch_);
+    result.selection_ = std::move(sel);
+    result.order_ = std::nullopt;
+    return result;
+  }
+
+  // Builder: create new RowSet with an order vector
+  RowSet withOrder(Permutation ord) const {
+    RowSet result(batch_);
+    result.selection_ = selection_;
+    result.order_ = std::move(ord);
+    return result;
+  }
+
+  // Builder: truncate to at most `limit` active rows
+  // Materializes active indices and creates a new selection
+  RowSet truncateTo(size_t limit) const {
+    auto indices = activeRows().toVector(limit);
+    RowSet result(batch_);
+    result.selection_ = std::move(indices);
+    result.order_ = std::nullopt; // Order is baked into the new selection
+    return result;
+  }
+
+  // Check if selection is present
+  bool hasSelection() const { return selection_.has_value(); }
+
+  // Check if order is present
+  bool hasOrder() const { return order_.has_value(); }
+
+private:
+  std::shared_ptr<const ColumnBatch> batch_;
+  std::optional<SelectionVector> selection_;
+  std::optional<Permutation> order_;
 };
 
 } // namespace rankd

--- a/engine/src/executor.cpp
+++ b/engine/src/executor.cpp
@@ -163,17 +163,18 @@ std::vector<RowSet> execute_plan(const Plan &plan, const ExecCtx &ctx) {
 
     std::vector<RowSet> inputs;
     for (const auto &inp : node.inputs) {
-      inputs.push_back(results[inp]);
+      inputs.push_back(results.at(inp));
     }
 
     auto validated_params = registry.validate_params(node.op, node.params);
-    results[node_id] = registry.execute(node.op, inputs, validated_params, ctx);
+    results.emplace(node_id,
+                    registry.execute(node.op, inputs, validated_params, ctx));
   }
 
   // Collect outputs
   std::vector<RowSet> outputs;
   for (const auto &out : plan.outputs) {
-    outputs.push_back(results[out]);
+    outputs.push_back(results.at(out));
   }
 
   return outputs;

--- a/engine/src/main.cpp
+++ b/engine/src/main.cpp
@@ -140,19 +140,19 @@ int main(int argc, char *argv[]) {
       // Merge all outputs into candidates
       for (const auto &rowset : outputs) {
         auto indices =
-            rowset.materializeIndexViewForOutput(rowset.batch->size());
+            rowset.materializeIndexViewForOutput(rowset.batch().size());
 
         // Get float column key_ids in ascending order for deterministic output
-        auto float_key_ids = rowset.batch->getFloatKeyIds();
+        auto float_key_ids = rowset.batch().getFloatKeyIds();
 
         for (uint32_t idx : indices) {
           json candidate;
-          candidate["id"] = rowset.batch->getId(idx);
+          candidate["id"] = rowset.batch().getId(idx);
 
           // Build fields from float columns
           json fields = json::object();
           for (uint32_t key_id : float_key_ids) {
-            const auto *col = rowset.batch->getFloatCol(key_id);
+            const auto *col = rowset.batch().getFloatCol(key_id);
             if (col && col->valid[idx]) {
               // Look up key name
               for (const auto &meta : rankd::kKeyRegistry) {

--- a/engine/tests/test_rowset.cpp
+++ b/engine/tests/test_rowset.cpp
@@ -18,13 +18,13 @@ TEST_CASE("viewer.follow creates batch with sequential ids", "[rowset][task]") {
   auto params = registry.validate_params("viewer.follow", params_json);
   RowSet source = registry.execute("viewer.follow", {}, params, empty_ctx);
 
-  REQUIRE(source.batch->size() == 10);
-  REQUIRE_FALSE(source.selection.has_value());
-  REQUIRE_FALSE(source.order.has_value());
+  REQUIRE(source.batch().size() == 10);
+  REQUIRE_FALSE(source.hasSelection());
+  REQUIRE_FALSE(source.hasOrder());
 
   SECTION("ids are 1-indexed") {
     for (size_t i = 0; i < 10; ++i) {
-      REQUIRE(source.batch->getId(i) == static_cast<int64_t>(i + 1));
+      REQUIRE(source.batch().getId(i) == static_cast<int64_t>(i + 1));
     }
   }
 }
@@ -46,27 +46,27 @@ TEST_CASE("take limits output and shares batch pointer", "[rowset][task]") {
   RowSet result = registry.execute("take", {source}, take_params, empty_ctx);
 
   SECTION("shares batch pointer (no copy)") {
-    REQUIRE(result.batch.get() == source.batch.get());
+    REQUIRE(result.batchPtr().get() == source.batchPtr().get());
   }
 
   SECTION("creates selection of first 5 elements") {
-    REQUIRE(result.selection.has_value());
-    REQUIRE(result.selection->size() == 5);
+    REQUIRE(result.hasSelection());
+    REQUIRE(result.logicalSize() == 5);
   }
 
   SECTION("output ids are [1,2,3,4,5]") {
-    auto indices = result.materializeIndexViewForOutput(result.batch->size());
+    auto indices = result.materializeIndexViewForOutput(result.batch().size());
     REQUIRE(indices.size() == 5);
 
     std::vector<int64_t> output_ids;
     for (uint32_t idx : indices) {
-      output_ids.push_back(result.batch->getId(idx));
+      output_ids.push_back(result.batch().getId(idx));
     }
     REQUIRE(output_ids == std::vector<int64_t>{1, 2, 3, 4, 5});
   }
 
   SECTION("materialize_count stays at 0") {
-    REQUIRE(result.batch->debug()->materialize_count == 0);
+    REQUIRE(result.batch().debug()->materialize_count == 0);
   }
 }
 
@@ -82,17 +82,16 @@ TEST_CASE("RowSet iteration with selection and order", "[rowset]") {
     // selection = [0, 2, 3, 5] (indices 1 and 4 are filtered out)
     // order = [5, 4, 3, 2, 1, 0] (reverse order)
     // Expected iteration: order filtered by selection -> [5, 3, 2, 0]
-    RowSet rs;
-    rs.batch = batch;
-    rs.selection = std::vector<uint32_t>{0, 2, 3, 5};
-    rs.order = std::vector<uint32_t>{5, 4, 3, 2, 1, 0};
+    RowSet rs = RowSet(batch)
+                    .withSelection(SelectionVector{0, 2, 3, 5})
+                    .withOrder(Permutation{5, 4, 3, 2, 1, 0});
 
     auto indices = rs.materializeIndexViewForOutput(batch->size());
 
-    REQUIRE(indices == std::vector<uint32_t>{5, 3, 2, 0});
+    REQUIRE(indices == std::vector<RowIndex>{5, 3, 2, 0});
 
     std::vector<int64_t> output_ids;
-    for (uint32_t idx : indices) {
+    for (RowIndex idx : indices) {
       output_ids.push_back(batch->getId(idx));
     }
     REQUIRE(output_ids == std::vector<int64_t>{60, 40, 30, 10});
@@ -100,29 +99,24 @@ TEST_CASE("RowSet iteration with selection and order", "[rowset]") {
   }
 
   SECTION("order only") {
-    RowSet rs;
-    rs.batch = batch;
-    rs.order = std::vector<uint32_t>{5, 3, 1, 4, 2, 0};
+    RowSet rs = RowSet(batch).withOrder(Permutation{5, 3, 1, 4, 2, 0});
 
     auto indices = rs.materializeIndexViewForOutput(batch->size());
-    REQUIRE(indices == std::vector<uint32_t>{5, 3, 1, 4, 2, 0});
+    REQUIRE(indices == std::vector<RowIndex>{5, 3, 1, 4, 2, 0});
   }
 
   SECTION("selection only") {
-    RowSet rs;
-    rs.batch = batch;
-    rs.selection = std::vector<uint32_t>{1, 3, 5};
+    RowSet rs = RowSet(batch).withSelection(SelectionVector{1, 3, 5});
 
     auto indices = rs.materializeIndexViewForOutput(batch->size());
-    REQUIRE(indices == std::vector<uint32_t>{1, 3, 5});
+    REQUIRE(indices == std::vector<RowIndex>{1, 3, 5});
   }
 
   SECTION("no selection, no order defaults to [0..N)") {
-    RowSet rs;
-    rs.batch = batch;
+    RowSet rs(batch);
 
     auto indices = rs.materializeIndexViewForOutput(batch->size());
-    REQUIRE(indices == std::vector<uint32_t>{0, 1, 2, 3, 4, 5});
+    REQUIRE(indices == std::vector<RowIndex>{0, 1, 2, 3, 4, 5});
   }
 }
 
@@ -138,10 +132,9 @@ TEST_CASE("take with selection and order combined", "[rowset][task]") {
   // selection=[0, 2] (indices 1, 3 filtered out)
   // order=[3, 2, 1, 0] (reverse)
   // Effective iteration: [2, 0] (3 and 1 filtered out by selection)
-  RowSet input;
-  input.batch = batch;
-  input.selection = std::vector<uint32_t>{0, 2};
-  input.order = std::vector<uint32_t>{3, 2, 1, 0};
+  RowSet input = RowSet(batch)
+                     .withSelection(SelectionVector{0, 2})
+                     .withOrder(Permutation{3, 2, 1, 0});
 
   SECTION("take(1) yields first in iteration order") {
     nlohmann::json take_params_json;
@@ -149,12 +142,12 @@ TEST_CASE("take with selection and order combined", "[rowset][task]") {
     auto take_params = registry.validate_params("take", take_params_json);
     RowSet result = registry.execute("take", {input}, take_params, empty_ctx);
 
-    REQUIRE(result.batch.get() == input.batch.get());
+    REQUIRE(result.batchPtr().get() == input.batchPtr().get());
 
-    auto indices = result.materializeIndexViewForOutput(result.batch->size());
+    auto indices = result.materializeIndexViewForOutput(result.batch().size());
     REQUIRE(indices.size() == 1);
     REQUIRE(indices[0] == 2);
-    REQUIRE(result.batch->getId(indices[0]) == 30);
+    REQUIRE(result.batch().getId(indices[0]) == 30);
   }
 
   SECTION("take(2) yields both in iteration order") {
@@ -163,7 +156,63 @@ TEST_CASE("take with selection and order combined", "[rowset][task]") {
     auto take_params = registry.validate_params("take", take_params_json);
     RowSet result = registry.execute("take", {input}, take_params, empty_ctx);
 
-    auto indices = result.materializeIndexViewForOutput(result.batch->size());
-    REQUIRE(indices == std::vector<uint32_t>{2, 0});
+    auto indices = result.materializeIndexViewForOutput(result.batch().size());
+    REQUIRE(indices == std::vector<RowIndex>{2, 0});
+  }
+}
+
+TEST_CASE("ActiveRows forEachIndex iterates correctly", "[rowset]") {
+  auto batch = std::make_shared<ColumnBatch>(5);
+  for (size_t i = 0; i < 5; ++i) {
+    batch->setId(i, static_cast<int64_t>(i));
+  }
+
+  SECTION("collects all indices via forEachIndex") {
+    RowSet rs = RowSet(batch).withSelection(SelectionVector{1, 3, 4});
+
+    std::vector<RowIndex> collected;
+    rs.activeRows().forEachIndex([&](RowIndex idx) { collected.push_back(idx); });
+
+    REQUIRE(collected == std::vector<RowIndex>{1, 3, 4});
+  }
+
+  SECTION("size() matches actual count") {
+    RowSet rs = RowSet(batch)
+                    .withSelection(SelectionVector{0, 1, 2, 3, 4})
+                    .withOrder(Permutation{4, 2, 0}); // Only 3 active after order filter
+
+    REQUIRE(rs.activeRows().size() == 3);
+    REQUIRE(rs.logicalSize() == 3);
+  }
+}
+
+TEST_CASE("RowSet truncateTo works correctly", "[rowset]") {
+  auto batch = std::make_shared<ColumnBatch>(10);
+  for (size_t i = 0; i < 10; ++i) {
+    batch->setId(i, static_cast<int64_t>(i * 10));
+  }
+
+  SECTION("truncateTo from full batch") {
+    RowSet rs(batch);
+    RowSet truncated = rs.truncateTo(3);
+
+    auto indices = truncated.materializeIndexViewForOutput(100);
+    REQUIRE(indices == std::vector<RowIndex>{0, 1, 2});
+    REQUIRE(truncated.logicalSize() == 3);
+  }
+
+  SECTION("truncateTo preserves iteration order") {
+    RowSet rs = RowSet(batch).withOrder(Permutation{9, 7, 5, 3, 1});
+    RowSet truncated = rs.truncateTo(3);
+
+    auto indices = truncated.materializeIndexViewForOutput(100);
+    REQUIRE(indices == std::vector<RowIndex>{9, 7, 5});
+  }
+
+  SECTION("truncateTo shares batch pointer") {
+    RowSet rs(batch);
+    RowSet truncated = rs.truncateTo(5);
+
+    REQUIRE(truncated.batchPtr().get() == rs.batchPtr().get());
   }
 }

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -316,4 +316,16 @@ else
 fi
 
 echo ""
+echo "=== Test 22: Verify no direct access to RowSet internals ==="
+# This check ensures task authors don't bypass the RowSet encapsulation.
+# The members selection_ and order_ are private, but this grep catches
+# any accidental future attempts to expose them or access them via friend.
+if grep -r --include='*.cpp' --include='*.h' -E '\.(selection_|order_)\b' engine/src engine/tests 2>/dev/null | grep -v 'rowset.h'; then
+    echo "FAIL: Found direct access to RowSet selection_/order_ internals outside rowset.h"
+    exit 1
+else
+    echo "PASS: No direct access to RowSet internals detected"
+fi
+
+echo ""
 echo "=== All CI tests passed ==="


### PR DESCRIPTION
## Summary
- Refactor RowSet from struct to class with private `selection_`/`order_` members
- Add `ActiveRows` view class for canonical iteration via `forEachIndex()`, `toVector()`, `size()`
- Add builder methods: `withBatch()`, `withSelection()`, `withOrder()`, `truncateTo()`
- Simplify task implementations (`take`, `vm`, `filter`) to use new APIs
- Add CI guardrail (Test 22) to detect direct access to internals

## Test plan
- [x] All 136 unit test assertions pass
- [x] All 22 CI tests pass
- [x] Smoke test with demo.plan.json works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)