### PR TITLE
RFC: Add design documents (0002-0005)

### DIFF
--- a/rfcs/0002-timeout-wrapper.md
+++ b/rfcs/0002-timeout-wrapper.md
@@ -1,0 +1,337 @@
+---
+rfc: 0002
+title: "Timeout Wrapper Meta-Task (Region Deadline + Deterministic Fallback)"
+status: Draft  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
+created: 2026-01-13
+updated: 2026-01-13
+authors:
+  - "<name>"
+approvers:
+  - "<name>"
+requires: [0001]
+replaces: []
+capability_id: "cap.rfc.0002.timeout_wrapper.v1"
+---
+
+# RFC 0002: Timeout Wrapper Meta-Task (Region Deadline + Deterministic Fallback)
+
+## 0. Summary
+This RFC introduces a **meta-task** `timeout_wrapper` that enforces a **region-level wall-clock deadline** for a subgraph and
+provides a deterministic policy on timeout:
+- **Fail the plan**, or
+- Execute a **fallback subgraph**.
+
+The wrapper preserves the system’s **fail-closed** posture and keeps downstream semantics **deterministic** by requiring:
+1) **RowSet shape is preserved** (v1: enrichment-only; no filter/sort/take/join/dedupe),
+2) The set of written keys for both branches is **compile-time exact** and **equal**
+   (`writes_exact(success) == writes_exact(fail)`),
+3) Success branch writes are executed under **transactional semantics** (commit-or-rollback) so partial writes never leak.
+
+Usage is gated by capability **`cap.rfc.0002.timeout_wrapper.v1`** (Scheme B, RFC 0001).
+
+## 1. Motivation
+Ranking pipelines often include “optional enrichment” or “best-effort scoring” regions whose latency can dominate tail latency.
+Operators need a **predictable latency bound** while still returning a structured response.
+Per-task timeouts are too granular and lead to scattered configuration and inconsistent downgrade behavior.
+
+We want a single, reviewable, auditable mechanism that:
+- Provides a **region deadline** (not just per-task budgets),
+- Maintains deterministic downstream contracts (same keys; same rowset shape),
+- Avoids “half-written keys” on timeout,
+- Integrates with tracing and critical-path tooling.
+
+## 2. Goals
+- G1: Provide a **region-level wall-clock deadline** for a subgraph.
+- G2: Provide deterministic timeout behavior: **fail plan** or **run fallback**.
+- G3: Preserve **RowSet shape** in v1 (enrichment-only) to avoid control-flow/merge complexity.
+- G4: Enforce deterministic downstream contracts via **exact, equal writes** for success/fallback.
+- G5: Ensure no partial writes leak via **transactional overlay** semantics.
+- G6: Integrate with observability (trace/audit) and link-time validation (fail-closed).
+
+## 3. Non-Goals (v1)
+- NG1: Catching arbitrary errors (logic/validation/type). Only timeout is catchable.
+- NG2: Supporting rowset-shape mutations inside the wrapped region (filter/sort/take/join/dedupe/concat that changes row count).
+- NG3: IO reliability patterns (retry/hedging/circuit breaker). These are separate meta-tasks.
+- NG4: Accepting runtime-unknown outputs; wrapper requires `writes_exact` for both branches.
+
+## 4. Proposal (high level)
+Introduce a new meta-task op: `timeout_wrapper`.
+
+A `timeout_wrapper` node references two callable subgraphs:
+- `if_success`: subgraph to execute under a region deadline,
+- `if_fail`: subgraph to execute if and only if `if_success` times out (when configured to fallback).
+
+The wrapper computes a deadline using a row-aware budget model:
+- `timeout_ms = clamp(min_ms, base_ms + per_row_us * active_rows / 1000, max_ms)`
+
+Optionally, it can apply an override budget from a param, but:
+- Override is **clamped**,
+- In **prod**, override **must not** come from request-level values (policy is enforced fail-closed).
+
+On timeout:
+- If `on_timeout = "fail_plan"` → fail the request/plan.
+- If `on_timeout = "fallback"` → rollback success writes and run `if_fail`.
+
+## 5. Detailed Design
+
+### 5.1 Capability gating (Scheme B)
+Artifacts that contain `timeout_wrapper` MUST include capability:
+- `cap.rfc.0002.timeout_wrapper.v1`
+
+The engine must fail-closed if the capability is required but unsupported. See RFC 0001.
+
+### 5.2 Authoring surface (TS)
+The authoring API SHOULD resemble fragment authoring (fluent chaining), but does not require the user to hand-author fragments.
+
+Example:
+
+```ts
+plan.timeout_wrapper({
+  if_success: (c, ctx) =>
+    c.fetch_features({ stage: "esr" })
+     .call_models({ stage: "esr", out: Key.score_model })
+     .vm(Key.score_final, dsl.add(Key.score_model, 1)),
+
+  if_fail: (c, ctx) =>
+    c.fill_defaults({ keys: [Key.score_model, Key.score_final] }),
+
+  budget: { base_ms: 2, per_row_us: 20, min_ms: 1, max_ms: 15 },
+
+  override: {
+    param: P.override_budget_ms,
+    allow_sources: ["plan", "fragment"], // prod default
+    min_ms: 1,
+    max_ms: 20,
+    combine: "min",
+  },
+
+  on_timeout: "fallback",
+});
+```
+
+Notes:
+- `fill_defaults` is an infra-owned helper task (see §5.7) to make “shape-equal” fallbacks easy.
+- V1 enforces `rowset_contract = preserve` (no rowset-changing ops).
+
+### 5.3 Compile-time lowering (Scheme A: lift subgraph to fragments)
+Although authoring may be inline, **dslc MUST lower** `if_success` and `if_fail` to callable subgraphs by lifting them into
+anonymous fragment artifacts (content-addressed by digest).
+
+Lowering requirements:
+- Each branch becomes a closed, callable fragment: it may only read keys available at wrapper input and params resolved at link-time.
+- Branch fragments are emitted deterministically and referenced by digest.
+- SourceRef/callsite spans must map runtime errors back to the original TS location.
+
+This lowering makes wrapper execution unambiguous (sequential branch execution within a transactional scope) without requiring nested DAG schemas.
+
+### 5.4 IR / JSON representation
+This RFC introduces a new node `op` value: `timeout_wrapper`.
+The base Plan/Fragment JSON schema does not otherwise change.
+
+#### 5.4.1 Node shape
+```jsonc
+{
+  "node_id": "n123",
+  "op": "timeout_wrapper",
+  "params": {
+    "success": {
+      "fragment_digest": "sha256:...",
+      "args": { /* resolved fragment args (link-time constants only) */ }
+    },
+    "fail": {
+      "fragment_digest": "sha256:...",
+      "args": { /* resolved fragment args */ }
+    },
+
+    "budget": {
+      "base_ms": 2,
+      "per_row_us": 20,
+      "min_ms": 1,
+      "max_ms": 15
+    },
+
+    "override": {
+      "param_id": "param.override_budget_ms",
+      "allow_sources": ["plan", "fragment"],
+      "min_ms": 1,
+      "max_ms": 20,
+      "combine": "min"
+    },
+
+    "on_timeout": "fallback", // or "fail_plan"
+    "rowset_contract": "preserve"
+  },
+
+  "trace": "optional-trace-string",
+  "source_span": { /* SourceRef */ }
+}
+```
+
+Defaults:
+- `rowset_contract` defaults to `"preserve"` and v1 only supports `"preserve"`.
+- `on_timeout` defaults to `"fail_plan"`.
+- `override` is optional; if absent, only the model budget is used.
+
+### 5.5 Validation rules (dslc + engine; fail-closed)
+All validation is performed in both dslc and the engine (belt-and-suspenders).
+
+#### 5.5.1 Branch closure
+- Branch subgraphs must be closed with respect to node dependencies (no references to outer node_ids).
+- Branch reads must only reference keys available at wrapper input.
+- Branch params that influence semantics MUST be link-time constants (see §5.5.3).
+
+#### 5.5.2 RowSet contract (v1)
+V1 requires `rowset_contract = "preserve"`.
+
+A branch is preserve iff:
+- It contains no rowset-mutating ops (at minimum: `filter`, `sort`, `take`, `dedupe`, `join`, and any op declared rowset-mutating).
+- All tasks used in the branch are declared rowset-preserving by their TaskSpec (or are in the engine’s preserve allowlist).
+- If a task’s rowset effect is unknown, validation fails.
+
+Runtime assert:
+- The engine MUST assert that active row count, selection, and permutation are unchanged across branch execution.
+
+#### 5.5.3 Exact key effects (deterministic shape)
+For both branches, the set of written keys MUST be derivable as an **exact set** at compile/link time:
+
+- For every node inside success/fail branches, `writes_exact(node)` must be computable.
+- If any node is only `writes_may` (e.g., output keys depend on runtime param/request), validation fails.
+
+Examples of disallowed patterns inside the wrapper (v1):
+- `fetch_features(stage=P.stage)` where `P.stage` is request-bound.
+- Any “param switch” that changes which bundle key is written unless the param is link-time constant.
+
+#### 5.5.4 Shape equality
+Let `W_success` and `W_fail` be the exact sets of keys written by each branch.
+
+Requirement:
+- `W_success == W_fail`
+
+If not equal, validation fails with a diff listing missing/extra keys per branch.
+
+#### 5.5.5 Override policy
+If `override` is present:
+- `override.param_id` must resolve to a number of milliseconds.
+- The resolved param’s **origin** must be in `override.allow_sources`.
+- In prod, `override.allow_sources` MUST NOT include request-origin values.
+- If origin policy is violated: fail-closed.
+
+Clamping:
+- `override_ms = clamp(min_ms, override_value, max_ms)`.
+- If clamp config is missing: fail-closed.
+
+Combine:
+- `"min"`: `timeout_ms = min(model_ms, override_ms)` (recommended default)
+- `"replace"`: `timeout_ms = override_ms` (allowed only if explicitly configured)
+
+### 5.6 Execution semantics (engine)
+#### 5.6.1 Deadline computation
+Let `n = active_row_count(input_rowset)`.
+
+- `model_ms = base_ms + (per_row_us * n) / 1000`
+- `model_ms = clamp(min_ms, model_ms, max_ms)`
+- If override exists: compute `override_ms` per §5.5.5 and combine.
+- Final: `timeout_ms` defines a region deadline `deadline = now + timeout_ms`.
+
+#### 5.6.2 Transactional writes
+The engine MUST execute the success branch under a transactional write overlay:
+- All writes are staged in an overlay (copy-on-write for columns/keys).
+- On success completion before deadline: **commit**.
+- On timeout: **rollback** (no writes leak).
+
+#### 5.6.3 Timeout detection
+Timeout is defined as wall-clock deadline exceeded.
+- Tasks inside the region should receive an execution context that exposes `deadline` / `time_remaining_ms()` and a cancellation check.
+- The region deadline bounds each child task’s effective deadline: `child_deadline = min(task_deadline, region_deadline)`.
+
+#### 5.6.4 Branch selection
+- If success finishes before deadline: commit; return.
+- If success times out:
+  - If `on_timeout = "fail_plan"`: return Timeout error (fail request/plan).
+  - If `on_timeout = "fallback"`:
+    - rollback success overlay,
+    - execute fail branch from the original input rowset,
+    - commit fail writes (fail branch still runs under normal per-task budgets; it does not inherit the expired deadline unless configured separately).
+
+#### 5.6.5 Error handling posture
+Only timeout triggers fallback.
+All other errors (validation failures, type errors, budget violations other than wall-clock timeout) fail the plan and do not run fallback.
+
+### 5.7 Helper task: `fill_defaults`
+To make shape-equal fallback practical, infra SHOULD provide a task:
+
+- `fill_defaults(keys: KeyId[])`
+
+Semantics:
+- For each key in `keys`:
+  - If key is nullable: write null
+  - Else: write registry default (fail if missing)
+
+This task is rowset-preserving and has deterministic behavior.
+
+### 5.8 Observability and audit
+The engine MUST emit wrapper-level trace fields:
+- `timeout_ms`, `nrows`
+- `success_elapsed_ms`, `timed_out` (bool)
+- `chosen_branch`: `"success" | "fail" | "fail_plan"`
+- `fail_elapsed_ms` (if executed)
+- `override_applied`: bool, `override_origin` (plan/fragment/request/source/default/null)
+- `W_success` size (optional), key ids list (optional; may be large)
+
+Child task spans should be nested under a wrapper span, and their timestamps should contribute to critical path tooling.
+On timeout failures, the error payload must include the wrapper node_id/op/trace and the computed timeout_ms.
+
+### 5.9 Caching impact
+- Usage of `timeout_wrapper` requires capability gating (RFC 0001).
+- Plan binary cache keys MUST include the capabilities digest.
+- The wrapper introduces no additional caching semantics beyond existing plan/fragment digests.
+- If the branches include IO tasks in the future, caching policy must be revisited (out of scope v1).
+
+### 5.10 Security / abuse resistance
+- Override is clamped and origin-restricted (prod disallows request-origin budget loosening).
+- Rowset-preserve v1 reduces the risk of semantic divergence and complexity.
+- Transactional overlay prevents partial writes from leaking during timeouts.
+
+## 6. Backward compatibility
+- Artifacts without `timeout_wrapper` are unaffected.
+- Engines that do not support this feature will fail-closed via capability gating.
+
+## 7. Alternatives considered
+1) **Per-task `on_timeout` configuration**
+   - Simple but leads to configuration sprawl and does not support region budgets.
+2) **Flattened control-flow DAG (mux/merge)**
+   - Higher complexity in IR and runtime scheduling; hard to reason about merge semantics.
+3) **Implicit auto-defaults on fallback**
+   - Convenient but reduces review transparency; this RFC prefers explicit shape-equal fallback (`fill_defaults`) and exact outputs.
+
+## 8. Risks and mitigations
+- R1: Wrapper becomes hard to use due to exact-key restrictions.
+  - Mitigation: Provide `fill_defaults`; require link-time constants for key-affecting params; keep v1 scope to enrichment-only.
+- R2: Hidden partial writes on timeout.
+  - Mitigation: Transactional overlay is mandatory; add unit tests for rollback correctness.
+- R3: Override budgets become a DoS vector.
+  - Mitigation: Clamp + origin policy; prod disallows request-origin loosening; trace override usage.
+
+## 9. Test plan
+- Unit tests:
+  - Transactional overlay commit/rollback: no partial writes on timeout.
+  - Exact writes inference fails when outputs depend on runtime params.
+  - Shape equality enforcement: success/fail key sets must match.
+  - Override clamp + origin policy enforcement.
+  - Only timeout triggers fallback; other errors fail plan.
+- Integration tests:
+  - A sample plan where success intentionally times out; verify fallback branch runs and keys shape matches.
+  - Trace includes wrapper fields and correct branch selection.
+  - Rowset shape unchanged across wrapper execution.
+
+## 10. Rollout plan
+- Step 1: Implement engine `timeout_wrapper` op with transactional overlay + deadline computation.
+- Step 2: Implement dslc lowering (lift branches to anonymous fragments) + validations (exact writes, preserve rowset, shape equality).
+- Step 3: Add `fill_defaults` helper task.
+- Step 4: Enable in dev/test; confirm trace/audit; then gate in prod via capability allowlist.
+
+## 11. Open questions (future work)
+- OQ1: Allow additional catch types (cpu/step budgets) while still disallowing mem-based fallback.
+- OQ2: Extend beyond rowset-preserve (support filter/sort/take) with explicit merge semantics.
+- OQ3: Add optional “region-local parallelism” semantics for executing branch subgraphs.
+- OQ4: Provide a first-class syntax for common fallback patterns (e.g., default outputs) without reducing review transparency.

--- a/rfcs/0003-debuggability-breakpoints-capture-after-request.md
+++ b/rfcs/0003-debuggability-breakpoints-capture-after-request.md
@@ -1,0 +1,336 @@
+---
+rfc: 0003
+title: "Debuggability: Breakpoints, RowSet Capture, and After-Request Postlude"
+status: Draft  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
+created: 2026-01-14
+updated: 2026-01-14
+authors:
+  - "<name>"
+approvers:
+  - "<name>"
+requires: [0001]
+replaces: []
+capability_id: "cap.rfc.0003.debug_capture_postlude.v1"
+---
+
+# RFC 0003: Debuggability — Breakpoints, RowSet Capture, and After-Request Postlude
+
+## 0. Summary
+This RFC introduces two complementary debuggability features:
+
+1) **Breakpoints (`assign`) + request-triggered capture**:
+   Plan/fragment authors label stable points in the pipeline with `.assign("<label>")`.
+   Requests can then ask the engine to **capture the entire RowSet** at those breakpoints, producing a **capture_id** that tools can analyze offline.
+
+2) **`after_request` postlude jobs**:
+   Plan authors attach an **after-request mini-pipeline** (stats/transform/serialize/emit) to a breakpoint.
+   The engine runs these jobs **after the critical path** (dev: synchronous postlude; prod: asynchronous queue) to support training-data logging and heavy serialization without impacting user latency.
+
+Both features preserve the project’s core posture:
+- runtime executes compiled IR,
+- strict validation (fail-closed),
+- deterministic naming and outputs,
+- capability gating via Scheme B (RFC 0001).
+
+## 1. Motivation
+A recurring pain point in declarative DAG pipelines is reasoning about:
+- What the candidate RowSet looks like at a specific stage (columns, nulls, distributions),
+- Why a stage changed counts/order (filter/sort/take),
+- How to produce reliable training-data logs without inflating P99 latency.
+
+Node IDs are not user-friendly and are unstable under compilation/linking.
+We need a first-class notion of **named stage points** (breakpoints) and a way to materialize the RowSet and/or derived artifacts for offline inspection and training pipelines.
+
+## 2. Goals
+- G1: Allow authors to label stable stage points using `.assign(label)` in both plans and fragments.
+- G2: Allow requests to trigger capture by breakpoint name (not node_id), producing a **capture_id**.
+- G3: Capture the **entire RowSet** (raw semantics: base_batch + selection + permutation + dicts) under strict limits and deterministic policies.
+- G4: Support heavy work after the response is determined/flushed via `after_request` jobs (dev inline postlude; prod async queue).
+- G5: Keep capture and postlude behavior deterministic, auditable, and fail-closed under policy violations.
+- G6: Provide a clean path to log training data without contaminating the critical path.
+
+## 3. Non-Goals (v1)
+- NG1: Arbitrary user-specified node_id targeting for capture (breakpoints only).
+- NG2: Turning `after_request` into a general-purpose compute platform (no join/model/feature fetch).
+- NG3: Guaranteeing postlude execution (prod is best-effort under backpressure).
+- NG4: Cross-request caching semantics for captured artifacts (out of scope).
+
+## 4. High-level design overview
+### 4.1 Breakpoints
+- `.assign("label")` tags the **current RowSet output point** without creating a new runtime task.
+- Labels are resolved into a **qualified breakpoint name** during compile/link:
+  `plan_name::instance_path::label`
+
+### 4.2 Two-phase capture
+To keep heavy work off the critical path:
+- **Phase A (freeze)**: at breakpoint time, create a lightweight **CaptureTicket** (O(1) ref-counting / COW).
+- **Phase B (serialize/store)**: after the request completes:
+  - dev: serialize/store synchronously in a postlude block (S1),
+  - prod: enqueue a job to serialize/store asynchronously (S3).
+
+### 4.3 After-request postlude jobs
+- Authors attach `after_request` jobs inline near the stage they care about.
+- dslc lowers them into `postlude_jobs[]` artifacts (lifted to fragments), anchored to breakpoints.
+- Jobs run after the response, using the captured breakpoint snapshot as input.
+- Job language is intentionally limited: **stats + transform (filter/take/sample/project) + serialize + emit**.
+
+## 5. Authoring surface (TypeScript)
+
+### 5.1 Breakpoints via `.assign()`
+```ts
+c.call_models({ stage: "esr", out: Key.score_model })
+ .assign("after_models")
+ .filter({ pred: (k) => k.score_model > 0.1 })
+ .assign("after_filter");
+```
+
+Semantics:
+- `.assign(label)` attaches a debug label to the “current” RowSet output point.
+- It returns the same fluent handle (no semantic change to the plan).
+
+### 5.2 Inline `after_request`
+Attach a postlude job anchored to the most recent assigned breakpoint (or an implicit anchor if absent):
+
+```ts
+c.call_models({ stage: "esr", out: Key.score_model })
+ .assign("after_models")
+ .after_request(ar =>
+   ar.filter((k) => k.score_model > 0.1)
+     .sample({ rows: 5000 })
+     .project([Key.id, Key.score_model, Key.country])
+     .describe({ keys: [Key.score_model] })
+     .serialize_rowset({ format: "arrow", mode: "raw" })
+     .emit_training_log({ sink: TrainSink.esr_v1, ttl_days: 7 })
+ );
+```
+
+Notes:
+- `filter(...)` inside `after_request` uses **PredIR** (compiled and validated like normal).
+- `sample` MUST be deterministic (seeded by run_id/request_id).
+- `emit_training_log` is an allowlisted sink (see §9).
+
+## 6. Breakpoint naming and scoping
+
+### 6.1 Qualified breakpoint names
+A local label is transformed into a qualified name:
+
+`<plan_name>::<instance_path>::<label>`
+
+- `plan_name`: declared in plan header (recommended), or a deterministic digest-based name if omitted.
+- `instance_path`: concatenation of fragment instance aliases along the call chain.
+- `label`: the literal string passed to `.assign()`.
+
+### 6.2 Instance aliases and determinism
+To prevent collisions when fragments are reused:
+- Fragment invocations SHOULD provide an explicit alias (recommended):
+  `use(fragment, { as: "esr" })`
+- If no alias is provided, dslc MUST generate a deterministic alias from callsite SourceRef/span id:
+  e.g. `__callsite_S123`.
+
+### 6.3 Validation
+Fail-closed at link time:
+- Labels MUST match a restricted charset (recommended: `[A-Za-z0-9._-]`) and MUST NOT contain `::`.
+- Qualified breakpoint names MUST be unique within a linked plan.
+- A node with a breakpoint label acts as an optimization barrier for any cross-instance node merging that would break mapping stability.
+
+## 7. Request-triggered capture
+
+### 7.1 Request schema (conceptual)
+Requests may include a capture directive by breakpoint name:
+
+```jsonc
+{
+  "debug_capture": [
+    {
+      "breakpoint": "MyPlan::esr::after_models",
+      "mode": "full_raw",          // stats | sample_raw | sample_view | full_raw | full_view
+      "limits": {
+        "max_bytes": 100000000,
+        "max_rows": 50000,
+        "max_columns": 2000
+      },
+      "sample": { "rows": 200 },
+      "include_columns": "ALL",    // or explicit list / patterns (optional)
+      "exclude_columns": ["feature_bundle"] // recommended default in prod
+    }
+  ]
+}
+```
+
+### 7.2 Capture modes
+- `stats`: compute schema + summary statistics only (no row data).
+- `sample_raw`: capture RowSet raw representation, but only for a deterministic sample of rows.
+- `sample_view`: apply selection/permutation and store a sampled materialized table.
+- `full_raw`: store full raw RowSet (base_batch + selection + permutation + dicts).
+- `full_view`: store full materialized view (more expensive).
+
+Recommendation:
+- Default `full_raw` in dev with strict limits.
+- Default `sample_raw` or `stats` in prod.
+
+### 7.3 Deterministic sampling
+Sampling must be deterministic using a stable seed:
+- seed = hash(run_id) (preferred) or hash(request_id)
+- sampling occurs over the RowSet view semantics (selection/permutation), then stored as raw or view as requested.
+
+### 7.4 Response payload
+The request returns capture handles:
+
+```jsonc
+{
+  "captures": [
+    {
+      "breakpoint": "MyPlan::esr::after_models",
+      "capture_id": "cap_9a12...",
+      "status": "queued" // dev may return "ready"; prod typically "queued"
+    }
+  ]
+}
+```
+
+## 8. Runtime execution model
+
+### 8.1 Phase A: Freeze at breakpoint
+At the moment a breakpoint node completes:
+- The engine creates a **CaptureTicket**:
+  - references the RowSet snapshot (base_batch + selection + permutation),
+  - records meta (breakpoint name, node_id, plan digest, registry digests, timestamps),
+  - records estimated size for budgeting/backpressure.
+
+Freeze MUST be O(1) in the common case (ref-count only), relying on the immutable/COW columnar model.
+
+### 8.2 Phase B: Serialize/store after request
+After the response is committed/flushed:
+
+- **Dev mode (S1)**: run postlude synchronously:
+  - serialize according to capture mode,
+  - store to debug store,
+  - return status `ready` with capture_id.
+
+- **Prod mode (S3)**: enqueue to a postlude queue:
+  - return status `queued` and capture_id immediately,
+  - worker serializes/stores later and updates status to `ready`/`failed`/`expired`.
+
+### 8.3 Backpressure and degradation policy
+To prevent capture from harming system stability:
+- enforce per-request limits: `max_bytes`, `max_rows`, `max_columns`.
+- enforce global limits: `max_inflight_tickets_bytes`, `max_inflight_jobs`.
+- deterministic degrade order on limit exceed:
+  `full_* → sample_* → stats → drop`
+- All degradation and drops must be logged with a machine-readable `drop_reason`.
+
+## 9. `after_request` postlude jobs
+
+### 9.1 Compilation model
+Each `.after_request(ar => ...)` is lowered into a `postlude_job`:
+- `anchor_breakpoint` (qualified name),
+- `job_fragment_digest` (lifted anonymous fragment),
+- `when` predicate (optional),
+- budgets/limits,
+- sinks.
+
+dslc collects all postlude jobs into the plan’s `extensions` under this RFC capability.
+
+### 9.2 Allowed task set (v1 allowlist)
+Postlude job DAG may contain only:
+
+**Stats**
+- `describe(keys=...)`, `histogram`, `topk`, etc.
+
+**Transform (RowSet-only)**
+- `filter(PredIR)`
+- `take(n)`
+- `sample(rows, seed=run_id)`
+- `project(keys=[...])`
+
+**Serialization**
+- `serialize_rowset(format, mode)`
+
+**Emit (the only IO)**
+- `emit_training_log(sink_id, ttl, payload_ref)`
+- `emit_capture_store(store_id, ttl, payload_ref)`
+
+Explicitly disallowed in v1:
+- `join`, `call_models`, `fetch_features`, arbitrary IO, any task that depends on external services other than allowlisted emit sinks.
+
+### 9.3 Inputs
+A postlude job consumes the snapshot identified by `anchor_breakpoint`.
+If multiple jobs share the same anchor, they may share the same frozen ticket.
+
+### 9.4 Execution timing and failure semantics
+- Jobs run after response completion.
+- Job failure MUST NOT affect the request response.
+- Failures must be observable: status, error code, and a stable job_id.
+
+### 9.5 Budgets
+Postlude jobs have independent budgets, enforced by the postlude worker:
+- wall-clock timeout (per job),
+- CPU/memory limits (implementation-defined),
+- output size limits (bytes/rows/columns),
+- sink-specific quotas.
+
+## 10. Storage model and handles
+
+### 10.1 Capture handles
+A capture is addressed by `capture_id` (opaque, non-guessable).
+`capture_id` resolves to a manifest describing:
+- status: `queued|running|ready|failed|expired|dropped`
+- artifact locations (object store paths, offsets),
+- metadata (breakpoint, plan digest, schema info, timestamps).
+
+### 10.2 Request_id indexing (optional)
+Engines may maintain an index from `request_id` to recent `capture_id`s, but the stable handle for tooling is `capture_id`.
+
+## 11. Observability
+### 11.1 Trace fields (recommended)
+For each capture:
+- breakpoint name, node_id
+- mode, limits, estimated size
+- chosen degrade level (if any)
+- freeze time, serialize time, bytes written
+- queue wait time (prod)
+
+For each postlude job:
+- job_id, anchor_breakpoint
+- status transitions, elapsed, bytes out
+- sink id, emit latency, retries (if any)
+- drop_reason / backpressure metrics
+
+### 11.2 Debug tooling
+Tooling SHOULD provide:
+- list breakpoints for a plan (`plan describe --breakpoints`),
+- fetch capture manifest by capture_id,
+- convert raw captures to a materialized view for interactive analysis,
+- diff two captures (optional future work).
+
+## 12. Security and policy
+- Captures and postlude emit sinks MUST be allowlisted by environment.
+- Prod policy SHOULD default to stats/sample and exclude large/PII-heavy columns unless explicitly permitted.
+- All captures must have TTL and be garbage-collected.
+- Access control to captured artifacts is enforced by the store and service layer (implementation-defined).
+
+## 13. Backward compatibility
+- Plans without these features are unaffected.
+- Engines that do not support this RFC will fail-closed via capability gating.
+
+## 14. Alternatives considered
+- Node-id targeting only: not user-friendly; unstable under compilation/linking.
+- Synchronous serialization on the critical path: harms tail latency.
+- Allowing arbitrary tasks in postlude: turns into a general compute platform; increases risk and complexity.
+
+## 15. Test plan
+- Compile/link tests:
+  - breakpoint naming, scoping, uniqueness; deterministic aliases from callsite.
+  - `.assign` produces stable breakpoint→node mapping.
+  - `.after_request` lowers into postlude_jobs with correct anchors.
+- Runtime tests:
+  - Freeze is O(1) (no eager materialization) and does not change main pipeline semantics.
+  - Dev mode: capture becomes ready after response; payload can be read and matches expectations.
+  - Prod mode: capture/job transitions queued→ready/failed; backpressure causes deterministic degradation/drops.
+  - Transform tasks in postlude (filter/take/sample/project) are deterministic and bounded.
+  - Only allowlisted emit sinks are permitted; policy violations fail-closed at link/load time.
+
+## 16. Open questions (future work)
+- Support compare/shadow meta-tasks based on captures (diff rank/score distributions).
+- Richer privacy controls (field-level redaction policies).
+- Additional postlude triggers: on_slow, on_error, targeted user cohort sampling.

--- a/rfcs/0004-runtime-branching-if-request.md
+++ b/rfcs/0004-runtime-branching-if-request.md
@@ -1,0 +1,265 @@
+---
+rfc: 0004
+title: "Runtime Request Branching and Compile-time Guardrails for Control Flow"
+status: Draft  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
+created: 2026-01-14
+updated: 2026-01-14
+authors:
+  - "<name>"
+approvers:
+  - "<name>"
+requires: [0001]
+replaces: []
+capability_id: "cap.rfc.0004.if_request_branching.v1"
+---
+
+# RFC 0004: Runtime Request Branching and Compile-time Guardrails for Control Flow
+
+## 0. Summary
+This RFC addresses a common authoring pitfall and introduces a first-class solution:
+
+1) **Compile-time guardrails**: prevent plan authors from using JavaScript/TypeScript control flow (`if`, `?:`, `&&`, `||`, `switch`) as if it were *runtime* branching. Since plans are built at compile-time, conditions that depend on runtime parameters (`P.*`) or data placeholders are invalid and must fail-closed with actionable errors.
+
+2) **`if_request` meta-task**: provide a first-class, IR-level runtime branch operator:
+`if_request(cond_bool, if_true=subgraph_a, if_false=subgraph_b)`
+
+`if_request` evaluates `cond_bool` once per request and executes exactly one branch, under strict, deterministic contracts:
+- v1 requires **RowSet shape preserved** (enrichment-only),
+- branch outputs must be **compile-time exact** and **shape-equal** (`writes_exact(true) == writes_exact(false)`),
+- branches are lowered by dslc into callable subgraphs (lifted fragments) with SourceRef mapping.
+
+Usage is capability-gated via Scheme B (RFC 0001) under `cap.rfc.0004.if_request_branching.v1`.
+
+## 1. Motivation
+In this system, TypeScript is executed only to **build** a graph and emit JSON IR; it is not executed per request.
+New authors frequently write:
+
+```ts
+if (P.use_new_model) { ... } else { ... }
+```
+
+This looks like runtime branching, but `P.use_new_model` is a placeholder object during plan build and is typically truthy,
+so the plan silently becomes **one fixed branch**, creating confusing and unsafe behavior.
+
+We need:
+- A safe, deterministic way to express **request-level** branching (feature flags, migrations, rollouts),
+- Clear, immediate feedback when authors attempt to use JS control flow incorrectly,
+- Strong governance and observability for branch selection.
+
+## 2. Goals
+- G1: Provide a first-class `if_request` meta-task for request-level branching.
+- G2: Enforce deterministic downstream contracts (same RowSet shape; same written keys) in v1.
+- G3: Make incorrect JS control-flow usage fail-closed at compile time with precise SourceRef spans and a suggested fix.
+- G4: Provide optional lint/IDE feedback to catch mistakes earlier (before invoking dslc).
+- G5: Preserve the “plan is a DAG” mental model: `if_request` is explicit in IR and traceable.
+
+## 3. Non-Goals (v1)
+- NG1: Per-row branching (use value-level constructs like `set_if` / `coalesce` / PredIR/ExprIR for that).
+- NG2: Allowing rowset-mutating ops inside branches (filter/sort/take/join) to influence the main pipeline’s RowSet.
+- NG3: A general control-flow language with arbitrary loops or nested branching.
+- NG4: Catch/try semantics (timeouts and fallbacks are handled by `timeout_wrapper`, RFC 0002).
+
+## 4. Proposal (high level)
+### 4.1 `if_request`
+Add a new meta-task op `if_request` that:
+- resolves a boolean condition (`cond_bool`) at runtime (per request),
+- executes exactly one of two callable subgraphs,
+- preserves RowSet shape in v1,
+- requires both branches to have **exact and identical** `writes` sets.
+
+### 4.2 Compile-time guardrails for JS control flow
+dslc must validate authoring TS/JS AST:
+- Any control-flow condition must be a **compile-time constant** (literal or allowed build-time constants such as `ctx.env`).
+- If a condition references `P.*` (runtime params) or other runtime placeholders, compilation fails with an error that points to the condition span and recommends `if_request`.
+
+## 5. Authoring surface (TypeScript)
+
+### 5.1 Recommended runtime branching
+A fluent API form (illustrative):
+
+```ts
+c.if_request({
+  cond: P.use_new_model,              // boolean param
+  if_true: (c) => c.call_models({ stage: "esr", out: Key.score_new })
+                 .fill_defaults({ keys: [Key.score_old] }),
+
+  if_false:(c) => c.call_models({ stage: "esr", out: Key.score_old })
+                 .fill_defaults({ keys: [Key.score_new] }),
+
+  trace: "model_rollout"
+});
+```
+
+Notes:
+- v1 enforces **rowset_preserve** in both branches.
+- v1 enforces **shape equality** on written keys; `fill_defaults` is the standard way to match shapes.
+
+### 5.2 Allowed compile-time branching (build-time constants only)
+This is allowed when the condition is compile-time known:
+
+```ts
+if (ctx.env === "dev") {
+  // dev-only nodes (not runtime)
+}
+```
+
+### 5.3 Disallowed pattern (must fail-closed)
+This must fail with a clear diagnostic:
+
+```ts
+if (P.use_new_model) { ... } else { ... }  // ❌ invalid: P.* is runtime
+```
+
+Error message must explain:
+- plans are built at compile time,
+- `P.*` is a runtime placeholder and cannot be used in JS conditions,
+- recommended fixes: use `if_request(...)` or select between plan artifacts at the server/router layer.
+
+## 6. Compilation model: lowering branches to callable subgraphs
+dslc MUST lower `if_true` and `if_false` subgraphs into callable units by lifting them into anonymous fragment artifacts
+(content-addressed by digest), identical to the lowering pattern used by `timeout_wrapper` (RFC 0002).
+
+Lowering requirements:
+- Branch subgraphs are **closed**: they may only read keys available at the `if_request` input point.
+- Any params that influence branch **key effects** must be link-time constants *except* the boolean `cond` itself (which is runtime).
+- SourceRef/callsite mapping must preserve error localization.
+
+## 7. IR / JSON representation
+This RFC introduces a new node `op`: `if_request`.
+
+```jsonc
+{
+  "node_id": "n_if_1",
+  "op": "if_request",
+  "params": {
+    "cond": { "param_id": "param.use_new_model" },
+    "if_true":  { "fragment_digest": "sha256:...", "args": {} },
+    "if_false": { "fragment_digest": "sha256:...", "args": {} },
+    "rowset_contract": "preserve"
+  },
+  "trace": "model_rollout",
+  "source_span": { /* SourceRef */ }
+}
+```
+
+Defaults:
+- `rowset_contract` defaults to `"preserve"` and v1 only supports `"preserve"`.
+
+## 8. Validation rules (dslc + engine; fail-closed)
+### 8.1 Condition type
+- `cond` must resolve to boolean at runtime.
+- `cond` origin may be request/plan/fragment per existing param binding rules (policy may restrict request overrides by env; out of scope v1).
+
+### 8.2 RowSet contract (v1)
+v1 requires `rowset_contract = preserve` for both branches:
+- branches must not contain rowset-mutating ops (filter/sort/take/dedupe/join/concat that changes row count),
+- tasks in branches must declare rowset-preserve in TaskSpec, otherwise validation fails.
+
+Runtime assert:
+- active row count, selection, and permutation are unchanged across branch execution.
+
+### 8.3 Exact key effects and shape equality
+Let `W_true` and `W_false` be the exact sets of keys written by each branch.
+
+Requirements:
+- Both branches must have **derivable exact writes** (no `writes_may`),
+- `W_true == W_false` (shape equality).
+
+If unequal, validation fails with a diff.
+
+### 8.4 Reads safety
+- Any key read in a branch must be present in the input schema at the `if_request` node.
+- Reads can be derived from TaskSpec reads and ExprIR/PredIR references (if used within the branch).
+
+## 9. Execution semantics (engine)
+- Resolve `cond` once per request at `if_request` execution time.
+- Execute exactly one branch subgraph in the current pipeline context.
+- Errors in the chosen branch fail the plan (no fallback behavior; use `timeout_wrapper` for timeout-based fallback).
+
+Observability:
+- Emit `chosen_branch=true|false` on the `if_request` span, plus elapsed time and basic row counts.
+
+## 10. Compile-time guardrails: disallow runtime placeholders in JS conditions
+dslc MUST perform an AST validation pass over plan/fragment authoring code.
+
+### 10.1 Guarded constructs
+At minimum:
+- `IfStatement.test`
+- `ConditionalExpression.test` (`cond ? a : b`)
+- `LogicalExpression` used in boolean contexts (common short-circuit branching): `&&`, `||`
+- `SwitchStatement.discriminant` (if supported)
+
+### 10.2 Allowed conditions (v1)
+Conditions are allowed only if they can be proven compile-time constant, e.g.:
+- boolean literals (`true`, `false`),
+- comparisons over build-time constants (`ctx.env === "dev"`) where `ctx.env` is known at plan build time,
+- other explicitly allowlisted build-time constants injected by the toolchain.
+
+### 10.3 Disallowed conditions (must fail-closed)
+Any condition that references runtime placeholders, including:
+- `P.*` (ParamRef),
+- request-dependent values,
+- any opaque objects not provably constant.
+
+### 10.4 Diagnostic requirements
+Diagnostics must include:
+- SourceRef span pointing to the condition,
+- an explanation of compile-time vs runtime semantics,
+- a suggested fix:
+  - use `if_request(P.flag, ...)` for request-level branching, or
+  - select between plan artifacts at the server/router layer for coarse rollout.
+
+## 11. Lint/IDE guidance (recommended)
+Provide an optional ESLint rule `no-paramref-in-conditions`:
+- flags `if (P.x)`, `cond ? ... : ...`, and boolean contexts involving ParamRefs,
+- suggests using `if_request` or `timeout_wrapper` depending on intent.
+
+This is a DX enhancement; dslc enforcement remains the source of truth.
+
+## 12. Caching impact
+- Plans using this feature must require capability `cap.rfc.0004.if_request_branching.v1`.
+- Binary cache key must include capabilities digest (RFC 0001).
+- No additional cache-key changes are required beyond existing plan/fragment/registry digests.
+
+## 13. Alternatives considered
+1) **Use JS `if` for everything**
+   - Incorrect for runtime branching; silently bakes one branch at build time; not auditable.
+2) **Server/router selects between two plan artifacts**
+   - Works, but splits governance/observability and complicates comparisons; still useful as an operational fallback.
+3) **Flattened DAG with mux/merge**
+   - Higher IR complexity and merge semantics; callable subgraph approach is simpler and consistent with other meta-tasks.
+
+## 14. Risks and mitigations
+- R1: Authors feel constrained by control-flow restrictions.
+  - Mitigation: allow build-time `ctx.env` branching; provide first-class `if_request` for runtime needs.
+- R2: Shape equality requirement is annoying.
+  - Mitigation: provide `fill_defaults` helper task and clear diagnostics showing the mismatch.
+- R3: Excessive branching complicates reasoning.
+  - Mitigation: keep v1 limited (request-level, preserve rowset) and rely on explicit trace markers.
+
+## 15. Test plan
+### 15.1 dslc AST validation
+- Reject `if (P.x)` with correct SourceRef and suggested fix.
+- Allow `if (ctx.env === "dev")` when env is build-time known.
+- Reject boolean contexts using ParamRefs (`P.x && ...`, `P.x ? ... : ...`).
+
+### 15.2 Link-time validation
+- Enforce rowset-preserve allowlist for branches.
+- Enforce `writes_exact` for both branches.
+- Enforce shape equality (`W_true == W_false`) with a clear diff.
+
+### 15.3 Runtime execution
+- Cond selects correct branch; only chosen branch tasks execute.
+- Trace includes chosen_branch and timing.
+- Errors in chosen branch fail plan.
+
+## 16. Rollout plan
+- Step 1: Add AST guardrails to dslc (fail-closed) and optional ESLint rule.
+- Step 2: Implement `if_request` in engine (callable subgraph execution) + validations.
+- Step 3: Expose TS authoring API and examples.
+- Step 4: Gate usage in prod via capability allowlist and monitor adoption/misuse diagnostics.
+
+## 17. Open questions
+- OQ1: Allow rowset-mutating ops inside `if_request` with explicit merge semantics (likely v2+).
+- OQ2: Allow multi-way branching (`switch_request`) for enums (v2+).
+- OQ3: Policy on request-origin param overrides for `cond` in prod environments.

--- a/rfcs/0005-key-effects-writes-exact.md
+++ b/rfcs/0005-key-effects-writes-exact.md
@@ -1,0 +1,259 @@
+---
+rfc: 0005
+title: "Key Effects and writes_exact: Compile-time Effect Inference for Deterministic RowSet Schema"
+status: Draft  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
+created: 2026-01-14
+updated: 2026-01-14
+authors:
+  - "<name>"
+approvers:
+  - "<name>"
+requires: [0001]
+replaces: []
+capability_id: "cap.rfc.0005.key_effects_writes_exact.v1"
+---
+
+# RFC 0005: Key Effects and `writes_exact` — Compile-time Effect Inference for Deterministic RowSet Schema
+
+## 0. Summary
+This RFC formalizes a lightweight **key effect system** over RowSet schema and defines the term **`writes_exact`** as a normative compile-time contract.
+
+We introduce:
+- A small, deterministic effect language for TaskSpec to describe how a task’s **written keys** depend on parameters.
+- A three-valued effect result: `Exact(K) | May(K) | Unknown`.
+- A compile/link-time evaluation procedure that produces `writes_exact` when (and only when) the effect is provably exact under link-time constants.
+- Subgraph aggregation rules and validation points used by meta-tasks (e.g., `timeout_wrapper`, `if_request`) to enforce deterministic “shape equality”.
+
+This RFC does **not** change the runtime execution model; it defines compile-time inference and validation rules and how they are consumed under Scheme B capability gating.
+
+Capability gate: `cap.rfc.0005.key_effects_writes_exact.v1`.
+
+## 1. Motivation
+Several meta-features require deterministic and reviewable guarantees about RowSet schema:
+- `timeout_wrapper` requires success/fallback branches to write the same keys deterministically.
+- `if_request` requires both branches to preserve RowSet shape and write the same keys deterministically.
+- Debug tooling benefits from compiler-produced “schema lens” information at each node.
+
+Without a formal definition, “writes_exact” becomes an informal idea with inconsistent interpretations, leading to:
+- divergent implementations across languages (TS/C++/Rust),
+- silent behavior changes during refactors,
+- weak or non-existent fail-closed validation for meta-tasks.
+
+This RFC makes key effect inference a first-class, testable contract.
+
+## 2. Goals
+- G1: Define `writes_exact` formally and make it decidable under a restricted effect language.
+- G2: Enable fail-closed validation when a feature requires deterministic schema (e.g., branch shape equality).
+- G3: Support tasks whose written keys depend on a small set of enumerated parameters (e.g., `stage`), without allowing arbitrary dynamic keys.
+- G4: Provide a uniform way to compute:
+  - `writes_exact(node)` (when possible),
+  - `writes_may(node)` (a safe finite over-approximation),
+  - and to reject `Unknown` effects in restricted contexts.
+- G5: Keep the effect system small enough to implement consistently in dslc and the engine.
+
+## 3. Non-Goals (v1)
+- NG1: Proving semantic properties of values (e.g., monotonicity, invariants) — only schema/key effects.
+- NG2: Per-row (data-dependent) effects or branching — effects may depend only on link-time constants and bounded enums.
+- NG3: Inferring effects from arbitrary user code — effects are declared in TaskSpec; inference only evaluates them.
+- NG4: Full dependent typing over values — this is an effect system / refinement over RowSet schema, not general dependent types.
+
+## 4. Definitions
+
+### 4.1 Key, RowSet schema
+- A **Key** is a registry-governed top-level field identified by stable `key_id`.
+- A RowSet schema at a point in the graph can be modeled as a set of keys that are present (with types/nullability from the registry).
+
+### 4.2 Compile/link-time environment Γ
+Γ contains information known at compile/link time:
+- literal constants in authoring code,
+- fragment args after linking (resolved constants),
+- plan-level constants (if supported),
+- build-time constants such as `ctx.env` (if supported).
+
+Γ does **not** include request-time values.
+
+### 4.3 Effect results
+Effect evaluation produces one of:
+
+- `Exact(K)`:
+  The task/subgraph will write exactly the finite set of keys `K`.
+- `May(K)`:
+  The task/subgraph may write some subset of `K`; `K` is a finite over-approximation.
+- `Unknown`:
+  A safe finite over-approximation is not available (or forbidden by policy).
+
+Define helper projections:
+- `keys(Exact(K)) = K`
+- `keys(May(K))   = K`
+- `keys(Unknown)  = ∅` (only for error reporting; not a valid over-approx)
+
+### 4.4 `writes_exact`
+`writes_exact(node)` is defined iff `writes_effect(node, Γ) = Exact(K)`.
+In that case, `writes_exact(node) = K`.
+
+Similarly:
+- `writes_may(node) = K` if `writes_effect(node, Γ) ∈ {Exact(K), May(K)}`.
+- `writes_may(node)` is undefined for `Unknown`.
+
+## 5. TaskSpec: declarative key effect language
+
+### 5.1 Requirement: no dynamic keys
+TaskSpec MUST NOT allow tasks to create keys dynamically from strings or data.
+All written keys must be expressible as a finite set of registry `key_id`s.
+
+### 5.2 Effect expression forms (v1)
+TaskSpec may declare `writes` using one of the following forms:
+
+1) **Static set**
+- `writes = Keys{K1, K2, ...}`
+
+2) **From key-valued param**
+- `writes = FromParam("out")`
+  - The param value must be a `key_id` at compile/link time for `Exact`.
+
+3) **Enum switch**
+- `writes = SwitchEnum(param="stage", cases={ "esr": Keys{Key.features_esr}, "lsr": Keys{Key.features_lsr} })`
+  - If `stage` is link-time constant → `Exact` of the selected case.
+  - If `stage` is not constant but domain is a bounded enum → `May` of the union.
+  - If domain is unknown/unbounded → `Unknown`.
+
+4) **Union**
+- `writes = Union([expr1, expr2, ...])`
+  - Combines multiple write sources (e.g., fixed outputs plus `FromParam(out)`).
+
+This restricted language is sufficient for common tasks:
+- `vm`: `FromParam("out")`
+- `extract_features`: `FromPath("map[].out")` (optional extension, see §5.3)
+- stage-dependent bundle tasks via `SwitchEnum`.
+
+### 5.3 Optional extension: path-based key lists
+For params that contain arrays/objects with embedded keys, TaskSpec may declare:
+- `FromPath("items[].out")`
+
+Semantics match `FromParam`, but the param value is a finite list of key_ids.
+`Exact` requires the list to be fully known at link time; otherwise `Unknown` (or `May` if bounded and enumerated).
+
+## 6. Effect evaluation (normative)
+
+### 6.1 Evaluation function
+Define `EvalWrites(effect_expr, Γ) -> Exact(K) | May(K) | Unknown`.
+
+Rules (v1):
+
+- `EvalWrites(Keys{K...}, Γ) = Exact({K...})`.
+
+- `EvalWrites(FromParam(p), Γ)`:
+  - if Γ binds param `p` to a concrete key_id (or finite list via FromPath): `Exact({key_id...})`
+  - else `Unknown` (unless a bounded domain is explicitly enumerated, in which case `May(union(domain))` is permitted by policy).
+
+- `EvalWrites(SwitchEnum(param, cases), Γ)`:
+  - if Γ binds `param` to a concrete enum value `v` and `v ∈ cases`: `Exact(keys(cases[v]))`
+  - else if `param` is not constant but its domain is a finite enum and `cases` covers the full domain: `May(union over cases)`
+  - else `Unknown`.
+
+- `EvalWrites(Union([e1..en]), Γ)`:
+  - evaluate each `ri = EvalWrites(ei, Γ)`
+  - if any `ri = Unknown`: result is `Unknown`
+  - else if all are `Exact`: `Exact(union(keys(ri)))`
+  - else: `May(union(keys(ri)))`
+
+### 6.2 Policy: where `May` is acceptable
+The system must distinguish contexts:
+- **Strong-shape contexts** (branching/fallback meta-tasks): `May` is not acceptable → must be `Exact`.
+- **Lens/tooling contexts** (schema preview, dependency graph): `May` is acceptable as an over-approximation.
+- **General compilation**: policy may allow `May` for warnings or tooling, but must not silently treat `May` as `Exact`.
+
+## 7. Subgraph aggregation rules
+
+### 7.1 Node-level effects
+Each node has a `writes_effect(node, Γ)` derived by evaluating the TaskSpec writes expression with node params under Γ.
+
+### 7.2 Subgraph writes
+For a subgraph `S` containing nodes `{n1..nk}`, define:
+
+- `writes_effect(S, Γ) = Union([writes_effect(n1, Γ), ..., writes_effect(nk, Γ)])`
+
+So:
+- `writes_exact(S)` exists iff every node’s effect is `Exact` (and no Unknown), and the union is `Exact`.
+
+### 7.3 Overwrite / conflict constraints
+This RFC does not redefine overwrite rules. However:
+- When aggregating `writes_exact`, implementations MUST still apply existing governance rules (e.g., “no overwrite” or “only explicit out keys”).
+- In strong-shape contexts, conflicting writes that would make output ambiguous MUST fail-closed.
+
+## 8. Interaction with RowSet shape effects
+TaskSpec already classifies rowset behavior (conceptually):
+- `Preserve` (enrichment-only)
+- `MutatesSelection` (filter)
+- `MutatesPermutation` (sort)
+- `MutatesRowCount` (join/concat/take etc., depending on semantics)
+
+This RFC focuses on key writes, but notes:
+- Meta-tasks such as `timeout_wrapper` and `if_request` additionally require `rowset_contract = preserve` in v1.
+- A future RFC may formalize `rowset_effect_exact` and merging semantics.
+
+## 9. Consuming `writes_exact` in meta-tasks (normative)
+
+### 9.1 `timeout_wrapper` (RFC 0002)
+V1 requires:
+- `rowset_contract = preserve`
+- `writes_exact(success) == writes_exact(fail)`
+
+If either branch yields `May` or `Unknown`, validation MUST fail-closed with a diagnostic identifying the node/param causing non-exact effects.
+
+### 9.2 `if_request` (RFC 0004)
+V1 requires:
+- `rowset_contract = preserve`
+- `writes_exact(if_true) == writes_exact(if_false)`
+
+Same failure posture as above.
+
+### 9.3 Debug capture & postlude jobs (RFC 0003)
+- Breakpoint naming and capture do not require `writes_exact`, but tooling may use `writes_may` to propose default column sets.
+- Postlude allowlists may use `rowset_effect` rather than `writes_exact` for enforcement.
+
+## 10. Diagnostics requirements (DX)
+When `Exact` is required but not available, the compiler must produce:
+- the specific node (op + node_id) and source span,
+- which param caused non-exactness (e.g., `stage`),
+- the computed `May{...}` set if applicable,
+- and a suggested fix (e.g., “make stage a link-time constant” or “use fill_defaults to equalize outputs”).
+
+Example message (conceptual):
+> Cannot prove writes_exact for node n12 (fetch_features): param `stage` is runtime-bound. In this context, deterministic shape is required.
+> Computed writes_may = {Key.features_esr, Key.features_lsr}. Fix: make `stage` a link-time constant (literal/fragment arg), or move this task outside the wrapper.
+
+## 11. Compatibility and rollout
+- This RFC introduces no breaking runtime changes.
+- dslc and engine must agree on effect evaluation and diagnostics; add golden tests and cross-language fixtures.
+- Capability gating: plans that rely on `writes_exact` in meta-task validations require `cap.rfc.0005.key_effects_writes_exact.v1` (directly or via dependent RFCs).
+
+## 12. Test plan
+### 12.1 Unit tests (dslc)
+- `vm(out=Key.x)` yields `Exact({Key.x})`.
+- `fetch_features(stage="esr")` yields `Exact({Key.features_esr})`.
+- `fetch_features(stage=P.stage)` with bounded enum yields `May({Key.features_esr, Key.features_lsr})`.
+- same case but unbounded domain yields `Unknown`.
+- Union combination rules for Exact/May/Unknown.
+
+### 12.2 Integration tests (meta-tasks)
+- `timeout_wrapper` rejects branches with `May` effects.
+- `if_request` rejects branches with mismatched Exact write sets.
+- Diagnostics include node_id, param name, and computed may set.
+
+### 12.3 Golden fixtures (cross-language)
+- A JSON fixture describing a TaskSpec writes expression and a set of Γ bindings, with expected result.
+- Run fixture tests in both dslc (TS) and engine (C++/Rust) implementations.
+
+## 13. Alternatives considered
+- Treat all param-dependent writes as Unknown and forbid them globally.
+  - Too restrictive; common patterns like stage bundles become painful.
+- Allow arbitrary dynamic keys.
+  - Breaks governance and determinism; not acceptable.
+- Full dependent type system over values.
+  - Overkill; we only need schema/effect refinement.
+
+## 14. Open questions
+- OQ1: Formalize `reads_exact` / `reads_may` similarly (especially for ExprIR/PredIR references).
+- OQ2: Extend effect language with bounded `FromPath` for common map/list patterns (extract_features).
+- OQ3: Formalize rowset mutation effects and merge semantics for future control-flow features.


### PR DESCRIPTION
## Summary
Add RFC design documents for future features. These are design specs, not implementation steps.

| RFC | Title | Summary |
|-----|-------|---------|
| 0002 | Timeout Wrapper | Region deadline, transactional rollback, fallback subgraph |
| 0003 | Debuggability | `.assign()` breakpoints, RowSet capture, `after_request` postlude |
| 0004 | Runtime Branching | `if_request` meta-task, compile-time guardrails |
| 0005 | Key Effects | `writes_exact` formalization, effect inference |

All RFCs:
- Require RFC 0001 (capability gating)
- Use subgraph lowering to callable fragments
- Require `writes_exact` for branch shape equality (where applicable)

## Test plan
- [x] Docs only, no code changes

🤖 Generated with [Claude Code](https://claude.ai/code)
