### PR TITLE
Step 10.6: Require clang-format for codegen

### DIFF
--- a/dsl/src/codegen.ts
+++ b/dsl/src/codegen.ts
@@ -308,9 +308,10 @@ function formatCpp(code: string): string {
       maxBuffer: 10 * 1024 * 1024,
     });
   } catch {
-    // If clang-format is not available, return unformatted
-    console.warn("Warning: clang-format not available, C++ output will be unformatted");
-    return code;
+    throw new Error(
+      "clang-format is required but not found.\n" +
+      "Install it via: brew install clang-format (macOS) or apt install clang-format (Linux)"
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- Codegen now fails with clear error if clang-format is not installed
- Includes install instructions for macOS (brew) and Linux (apt)

## Test plan
- [x] Verified codegen still works when clang-format is available
- [x] Verified no diff between codegen output and separate clang-format run

🤖 Generated with [Claude Code](https://claude.ai/code)
