### PR TITLE
Step 12.3a: Engine evaluates writes contract per node

### DIFF
--- a/engine/include/executor.h
+++ b/engine/include/executor.h
@@ -8,7 +8,8 @@
 namespace rankd {
 
 // Validate plan (fail-closed). Throws std::runtime_error on failure.
-void validate_plan(const Plan &plan);
+// Also populates node.writes_eval_kind and node.writes_eval_keys (RFC0005).
+void validate_plan(Plan &plan);
 
 // Execute plan and return output RowSets (one per outputs entry).
 std::vector<RowSet> execute_plan(const Plan &plan, const ExecCtx &ctx);

--- a/engine/include/plan.h
+++ b/engine/include/plan.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "writes_effect.h"
 #include <memory>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -17,6 +18,10 @@ struct Node {
 
   // RFC0001: node-level extensions (keys must be in plan.capabilities_required)
   nlohmann::json extensions;
+
+  // RFC0005: Evaluated writes contract (populated during validation)
+  EffectKind writes_eval_kind = EffectKind::Unknown;
+  std::vector<uint32_t> writes_eval_keys;  // sorted, deduped; empty for Unknown
 };
 
 // ExprNode: recursive expression tree (for vm expressions)

--- a/engine/include/writes_effect.h
+++ b/engine/include/writes_effect.h
@@ -63,6 +63,16 @@ WritesEffect eval_writes(const WritesEffectExpr &expr, const EffectGamma &gamma)
 // Serialize writes_effect to JSON for manifest digest
 std::string serialize_writes_effect(const WritesEffectExpr &expr);
 
+// Convert EffectKind to string for JSON output
+inline const char* effect_kind_to_string(EffectKind kind) {
+  switch (kind) {
+    case EffectKind::Exact: return "Exact";
+    case EffectKind::May: return "May";
+    case EffectKind::Unknown: return "Unknown";
+  }
+  return "Unknown";
+}
+
 // Helper to create EffectKeys
 inline std::shared_ptr<WritesEffectExpr> makeEffectKeys(std::vector<uint32_t> key_ids) {
   return std::make_shared<WritesEffectExpr>(EffectKeys{std::move(key_ids)});


### PR DESCRIPTION
## Summary
- Add `writes_eval_kind` and `writes_eval_keys` fields to Node struct (RFC0005)
- Add `build_param_bindings()` using `ValidatedParams` (not raw JSON) to ensure defaults are applied and types normalized
- Evaluate writes contract during `validate_plan()` and store result on node metadata
- Extend `--print-plan-info` to output nodes array with `writes_eval` per node
- Fail-closed for unsupported capabilities: exit 1 with structured error
- Add CI tests 55-56 for writes_eval validation

## Example Output (valid plan)
```json
{
  "plan_name": "reels_plan_a",
  "nodes": [
    {"node_id": "n0", "op": "viewer.follow", "writes_eval": {"kind": "Exact", "keys": [3001, 3002]}},
    {"node_id": "n1", "op": "vm", "writes_eval": {"kind": "Exact", "keys": [2001]}},
    {"node_id": "n2", "op": "filter", "writes_eval": {"kind": "Exact", "keys": []}},
    {"node_id": "n3", "op": "take", "writes_eval": {"kind": "Exact", "keys": []}}
  ]
}
```

## Example Output (unsupported capabilities, exit 1)
```json
{
  "plan_name": "test_plan",
  "capabilities_required": ["cap.audit", "cap.debug"],
  "capabilities_digest": "sha256:...",
  "error": {
    "code": "UNSUPPORTED_CAPABILITY",
    "unsupported": ["cap.audit", "cap.debug"]
  }
}
```

## Test plan
- [x] CI passes (all 56 tests)
- [x] Test 55: `--print-plan-info` shows nodes with correct writes_eval
- [x] Test 56: `--print-plan-info` returns structured error for unsupported capabilities (exit 1)
- [x] Uses ValidatedParams for param_bindings (defaults + type normalization applied)

🤖 Generated with [Claude Code](https://claude.ai/code)
