### PR TITLE
Step 12.3b: Fixtures + tests for writes_eval in --print-plan-info

### DIFF
--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -137,3 +137,22 @@ target_link_libraries(writes_effect_tests PRIVATE nlohmann_json::nlohmann_json C
 set_target_properties(writes_effect_tests PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
 )
+
+# Plan info writes_eval tests executable (Catch2)
+add_executable(plan_info_tests
+  tests/test_plan_info_writes_eval.cpp
+  src/plan.cpp
+  src/executor.cpp
+  src/task_registry.cpp
+  src/output_contract.cpp
+  src/capability_registry.cpp
+  src/writes_effect.cpp
+  ${TASK_SOURCES}
+)
+
+target_include_directories(plan_info_tests PRIVATE ${CMAKE_SOURCE_DIR}/include)
+target_link_libraries(plan_info_tests PRIVATE nlohmann_json::nlohmann_json Catch2::Catch2WithMain re2::re2)
+
+set_target_properties(plan_info_tests PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/bin"
+)

--- a/engine/tests/fixtures/plan_info/fixed_source.plan.json
+++ b/engine/tests/fixtures/plan_info/fixed_source.plan.json
@@ -1,0 +1,55 @@
+{
+  "built_by": {
+    "backend": "quickjs",
+    "bundle_digest": "5a3e61fa3a4edbbb",
+    "tool": "dslc",
+    "tool_version": "0.1.0"
+  },
+  "nodes": [
+    {
+      "inputs": [],
+      "node_id": "n0",
+      "op": "viewer.follow",
+      "params": {
+        "fanout": 4,
+        "trace": "L"
+      }
+    },
+    {
+      "inputs": [],
+      "node_id": "n1",
+      "op": "viewer.fetch_cached_recommendation",
+      "params": {
+        "fanout": 4,
+        "trace": "R"
+      }
+    },
+    {
+      "inputs": [
+        "n0",
+        "n1"
+      ],
+      "node_id": "n2",
+      "op": "concat",
+      "params": {
+        "trace": "C"
+      }
+    },
+    {
+      "inputs": [
+        "n2"
+      ],
+      "node_id": "n3",
+      "op": "take",
+      "params": {
+        "count": 8,
+        "trace": "T"
+      }
+    }
+  ],
+  "outputs": [
+    "n3"
+  ],
+  "plan_name": "concat_plan",
+  "schema_version": 1
+}

--- a/engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json
+++ b/engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json
@@ -1,0 +1,92 @@
+{
+  "built_by": {
+    "backend": "quickjs",
+    "bundle_digest": "acb5119052ec1f24",
+    "tool": "dslc",
+    "tool_version": "0.1.0"
+  },
+  "expr_table": {
+    "e0": {
+      "a": {
+        "key_id": 1,
+        "op": "key_ref"
+      },
+      "b": {
+        "a": {
+          "op": "param_ref",
+          "param_id": 1
+        },
+        "b": {
+          "op": "const_number",
+          "value": 0.2
+        },
+        "op": "coalesce"
+      },
+      "op": "mul"
+    }
+  },
+  "nodes": [
+    {
+      "inputs": [],
+      "node_id": "n0",
+      "op": "viewer.follow",
+      "params": {
+        "fanout": 10,
+        "trace": "src"
+      }
+    },
+    {
+      "inputs": [
+        "n0"
+      ],
+      "node_id": "n1",
+      "op": "vm",
+      "params": {
+        "expr_id": "e0",
+        "out_key": 2001,
+        "trace": "vm_final"
+      }
+    },
+    {
+      "inputs": [
+        "n1"
+      ],
+      "node_id": "n2",
+      "op": "filter",
+      "params": {
+        "pred_id": "p0",
+        "trace": "filter"
+      }
+    },
+    {
+      "inputs": [
+        "n2"
+      ],
+      "node_id": "n3",
+      "op": "take",
+      "params": {
+        "count": 5,
+        "trace": "take"
+      }
+    }
+  ],
+  "outputs": [
+    "n3"
+  ],
+  "plan_name": "reels_plan_a",
+  "pred_table": {
+    "p0": {
+      "a": {
+        "key_id": 2001,
+        "op": "key_ref"
+      },
+      "b": {
+        "op": "const_number",
+        "value": 0.6
+      },
+      "cmp": ">=",
+      "op": "cmp"
+    }
+  },
+  "schema_version": 1
+}

--- a/engine/tests/test_plan_info_writes_eval.cpp
+++ b/engine/tests/test_plan_info_writes_eval.cpp
@@ -1,0 +1,161 @@
+#include <catch2/catch_test_macros.hpp>
+
+#include "executor.h"
+#include "key_registry.h"
+#include "plan.h"
+#include "writes_effect.h"
+#include <algorithm>
+
+using namespace rankd;
+
+// Helper to find a node by op in the parsed plan
+static const Node* find_node_by_op(const Plan& plan, const std::string& op) {
+  for (const auto& node : plan.nodes) {
+    if (node.op == op) {
+      return &node;
+    }
+  }
+  return nullptr;
+}
+
+// Helper to check keys are sorted and unique
+static bool is_sorted_unique(const std::vector<uint32_t>& keys) {
+  if (keys.empty()) return true;
+  for (size_t i = 1; i < keys.size(); ++i) {
+    if (keys[i] <= keys[i - 1]) return false;
+  }
+  return true;
+}
+
+TEST_CASE("Fixture A: vm + row-only ops writes_eval", "[writes_eval][plan_info]") {
+  // Load the vm_and_row_ops fixture
+  Plan plan = parse_plan("engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json");
+
+  // Validate to populate writes_eval fields
+  validate_plan(plan);
+
+  SECTION("vm node has Exact with out_key") {
+    const Node* vm = find_node_by_op(plan, "vm");
+    REQUIRE(vm != nullptr);
+
+    // vm node should have Exact kind
+    REQUIRE(vm->writes_eval_kind == EffectKind::Exact);
+
+    // vm node should have exactly the out_key (2001 = final_score)
+    REQUIRE(vm->writes_eval_keys.size() == 1);
+    REQUIRE(vm->writes_eval_keys[0] == static_cast<uint32_t>(KeyId::final_score));
+
+    // Keys should be sorted and unique
+    REQUIRE(is_sorted_unique(vm->writes_eval_keys));
+  }
+
+  SECTION("filter node has Exact with empty keys") {
+    const Node* filter = find_node_by_op(plan, "filter");
+    REQUIRE(filter != nullptr);
+
+    REQUIRE(filter->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(filter->writes_eval_keys.empty());
+  }
+
+  SECTION("take node has Exact with empty keys") {
+    const Node* take = find_node_by_op(plan, "take");
+    REQUIRE(take != nullptr);
+
+    REQUIRE(take->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(take->writes_eval_keys.empty());
+  }
+
+  SECTION("viewer.follow source has Exact with fixed writes") {
+    const Node* source = find_node_by_op(plan, "viewer.follow");
+    REQUIRE(source != nullptr);
+
+    REQUIRE(source->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(source->writes_eval_keys.size() == 2);
+
+    // Should contain country (3001) and title (3002)
+    REQUIRE(std::find(source->writes_eval_keys.begin(),
+                      source->writes_eval_keys.end(),
+                      static_cast<uint32_t>(KeyId::country)) != source->writes_eval_keys.end());
+    REQUIRE(std::find(source->writes_eval_keys.begin(),
+                      source->writes_eval_keys.end(),
+                      static_cast<uint32_t>(KeyId::title)) != source->writes_eval_keys.end());
+
+    // Keys should be sorted and unique
+    REQUIRE(is_sorted_unique(source->writes_eval_keys));
+  }
+}
+
+TEST_CASE("Fixture B: fixed-writes source writes_eval", "[writes_eval][plan_info]") {
+  // Load the fixed_source fixture
+  Plan plan = parse_plan("engine/tests/fixtures/plan_info/fixed_source.plan.json");
+
+  // Validate to populate writes_eval fields
+  validate_plan(plan);
+
+  SECTION("viewer.fetch_cached_recommendation has Exact with country key") {
+    const Node* cached = find_node_by_op(plan, "viewer.fetch_cached_recommendation");
+    REQUIRE(cached != nullptr);
+
+    REQUIRE(cached->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(!cached->writes_eval_keys.empty());
+
+    // Should contain country (3001)
+    REQUIRE(std::find(cached->writes_eval_keys.begin(),
+                      cached->writes_eval_keys.end(),
+                      static_cast<uint32_t>(KeyId::country)) != cached->writes_eval_keys.end());
+
+    // Keys should be sorted and unique
+    REQUIRE(is_sorted_unique(cached->writes_eval_keys));
+  }
+
+  SECTION("concat node has Exact with empty keys") {
+    const Node* concat = find_node_by_op(plan, "concat");
+    REQUIRE(concat != nullptr);
+
+    REQUIRE(concat->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(concat->writes_eval_keys.empty());
+  }
+
+  SECTION("take node has Exact with empty keys") {
+    const Node* take = find_node_by_op(plan, "take");
+    REQUIRE(take != nullptr);
+
+    REQUIRE(take->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(take->writes_eval_keys.empty());
+  }
+
+  SECTION("viewer.follow source has Exact with fixed writes") {
+    const Node* source = find_node_by_op(plan, "viewer.follow");
+    REQUIRE(source != nullptr);
+
+    REQUIRE(source->writes_eval_kind == EffectKind::Exact);
+    REQUIRE(source->writes_eval_keys.size() == 2);
+
+    // Keys should be sorted and unique
+    REQUIRE(is_sorted_unique(source->writes_eval_keys));
+  }
+}
+
+TEST_CASE("writes_eval keys are always sorted and unique", "[writes_eval][plan_info]") {
+  // Test both fixtures to ensure keys are always sorted and unique
+
+  SECTION("vm_and_row_ops fixture") {
+    Plan plan = parse_plan("engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json");
+    validate_plan(plan);
+
+    for (const auto& node : plan.nodes) {
+      INFO("Checking node: " << node.node_id << " (" << node.op << ")");
+      REQUIRE(is_sorted_unique(node.writes_eval_keys));
+    }
+  }
+
+  SECTION("fixed_source fixture") {
+    Plan plan = parse_plan("engine/tests/fixtures/plan_info/fixed_source.plan.json");
+    validate_plan(plan);
+
+    for (const auto& node : plan.nodes) {
+      INFO("Checking node: " << node.node_id << " (" << node.op << ")");
+      REQUIRE(is_sorted_unique(node.writes_eval_keys));
+    }
+  }
+}

--- a/rfcs/0005-key-effects-writes-exact.md
+++ b/rfcs/0005-key-effects-writes-exact.md
@@ -1,9 +1,9 @@
 ---
 rfc: 0005
 title: "Key Effects and writes_exact: Core Effect Inference + Strict Shape Enforcement"
-status: Draft  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
+status: Implemented  # Draft | Review | Accepted | Implemented | Final | Rejected | Superseded
 created: 2026-01-14
-updated: 2026-01-16
+updated: 2026-01-18
 authors:
   - "<name>"
 approvers:
@@ -117,32 +117,40 @@ Similarly:
 - `writes_may(node) = K` if `writes_effect(node, Γ) ∈ {Exact(K), May(K)}`
 - `writes_may(node)` is undefined for `Unknown`
 
-### 4.5 Artifact metadata: key_effects (core)
-Compilers MUST emit derived key-effect metadata in the artifact, at least for each node.
+### 4.5 Engine-evaluated writes_eval (core)
 
-Node JSON shape (normative):
+The engine evaluates key effects **at plan-load time** during `validate_plan()`. Effects are stored on the parsed Node struct and exposed via `--print-plan-info`.
 
-```jsonc
+Node struct fields (C++):
+```cpp
+struct Node {
+  // ... existing fields ...
+  EffectKind writes_eval_kind = EffectKind::Unknown;  // Exact | May | Unknown
+  std::vector<uint32_t> writes_eval_keys;             // sorted, deduped; empty for Unknown
+};
+```
+
+CLI output shape (`--print-plan-info`, normative):
+```json
 {
-  "node_id": "n12",
-  "op": "fetch_features",
-
-  // Core metadata (optional field; if present must follow this schema)
-  "key_effects": {
-    "writes": {
-      "kind": "exact" | "may" | "unknown",
-      "keys": ["key.score_final", "key.features_esr"] // present iff kind != "unknown"
+  "nodes": [
+    {
+      "node_id": "n12",
+      "op": "fetch_features",
+      "writes_eval": {
+        "kind": "Exact",
+        "keys": [2001, 4001]
+      }
     }
-  }
+  ]
 }
 ```
 
 Rules:
-- `key_effects` MUST be omitted if the compiler chooses not to emit metadata, but when emitted it MUST be complete + canonical.
-- `writes.keys` MUST be sorted + unique.
-- When `kind = "unknown"`, the `keys` field MUST be omitted.
-
-Note: Implementations MAY recompute effects internally; if they do, they SHOULD verify any emitted `key_effects` matches the normative evaluation rules in this RFC.
+- `writes_eval.kind` is one of: `"Exact"`, `"May"`, `"Unknown"` (PascalCase)
+- `writes_eval.keys` MUST be sorted + unique (by key_id ascending)
+- When `kind = "Unknown"`, `keys` is empty `[]`
+- Engine MUST populate `writes_eval` for all nodes during validation
 
 ## 5. TaskSpec: declarative key effect language
 
@@ -150,31 +158,68 @@ Note: Implementations MAY recompute effects internally; if they do, they SHOULD 
 TaskSpec MUST NOT allow tasks to create keys dynamically from strings or data.
 All written keys must be expressible as a finite set of registry `key_id`s.
 
-### 5.2 Effect expression forms (v1)
-TaskSpec may declare `writes` using one of the following forms:
+### 5.2 Writes Contract: two-field design (v1)
 
-1) Static set
-- `writes = Keys{K1, K2, ...}`
+TaskSpec declares writes using **two complementary fields**:
 
-2) From key-valued param
-- `writes = FromParam("out")`
-  - The param value must be a `key_id` at compile/link time for `Exact`.
+```cpp
+struct TaskSpec {
+  std::vector<KeyId> writes;                     // Fixed/static key writes
+  std::optional<WritesEffectExpr> writes_effect; // Dynamic/param-dependent
+};
+```
 
-3) Enum switch
-- `writes = SwitchEnum(param="stage", cases={ "esr": Keys{Key.features_esr}, "lsr": Keys{Key.features_lsr} })`
-  - If `stage` is link-time constant -> `Exact` of the selected case.
-  - If `stage` is not constant but domain is a bounded enum -> `May` of the union.
-  - If domain is unknown/unbounded -> `Unknown`.
+The **Writes Contract** is computed as:
+```
+Writes Contract = UNION( Keys(writes), writes_effect )
+```
 
-4) Union
-- `writes = Union([expr1, expr2, ...])`
-  - Combines multiple write sources (e.g., fixed outputs plus `FromParam(out)`).
+**Key insight:** Most tasks only fill ONE field:
+- Source tasks (fixed schema) → `.writes = {3001, 3002}`, omit `.writes_effect`
+- Row-only ops (filter, take) → `.writes = {}`, omit `.writes_effect`
+- Param-dependent ops (vm) → `.writes = {}`, `.writes_effect = EffectFromParam{"out_key"}`
+
+### 5.3 Effect expression forms
+
+The `.writes_effect` field uses one of the following forms:
+
+1) **EffectKeys** - Static set (rarely used directly; prefer `.writes`)
+```cpp
+EffectKeys{{K1, K2, ...}}
+```
+
+2) **EffectFromParam** - Key from param value
+```cpp
+EffectFromParam{"out_key"}
+```
+- The param value must be a `key_id` at link time for `Exact`.
+
+3) **EffectSwitchEnum** - Enum-dependent keys
+```cpp
+EffectSwitchEnum{"stage", {{"esr", makeEffectKeys({4001})}, {"lsr", makeEffectKeys({4002})}}}
+```
+- If `stage` is link-time constant → `Exact` of the selected case.
+- If `stage` is not constant but domain is bounded → `May` of the union.
+- If domain is unknown/unbounded → `Unknown`.
+
+4) **EffectUnion** - Combines multiple sources
+```cpp
+EffectUnion{{makeEffectKeys({1001}), makeEffectFromParam("out")}}
+```
+
+### 5.4 compute_effective_writes() helper
+
+The engine provides `compute_effective_writes(spec)` to compute the union:
+- If only `.writes` → `EffectKeys{writes}`
+- If only `.writes_effect` → `*writes_effect`
+- If both → `EffectUnion{Keys(writes), *writes_effect}`
+- If neither → `EffectKeys{}` (empty, no writes)
 
 This restricted language is sufficient for common tasks:
-- `vm`: `FromParam("out")`
-- stage-dependent bundle tasks via `SwitchEnum`.
+- `vm`: `EffectFromParam{"out_key"}`
+- stage-dependent bundle tasks via `EffectSwitchEnum`.
 
-### 5.3 Optional extension: path-based key lists
+### 5.5 Optional extension: path-based key lists (not yet implemented)
 For params that contain arrays/objects with embedded keys, TaskSpec may declare:
 - `FromPath("items[].out")`
 
@@ -183,27 +228,54 @@ Semantics match `FromParam`, but the param value is a finite list of key_ids.
 
 ## 6. Effect evaluation (normative)
 
-### 6.1 Evaluation function
-Define `EvalWrites(effect_expr, Γ) -> Exact(K) | May(K) | Unknown`.
+### 6.1 param_bindings (Γ)
+
+The evaluation environment `param_bindings` (formerly called Γ) maps param names to their concrete values:
+
+```cpp
+using EffectGamma = std::map<std::string, std::variant<uint32_t, std::string>>;
+```
+
+It is built from `ValidatedParams` (which has defaults applied and types normalized):
+- **Int params** → `uint32_t` (for `EffectFromParam`, e.g., `out_key`)
+- **String params** → `std::string` (for `EffectSwitchEnum`, e.g., `stage`)
+
+Example:
+```cpp
+// Node params: {"out_key": 2001, "trace": "vm_final"}
+// param_bindings: {"out_key" → 2001}
+```
+
+### 6.2 Evaluation function
+
+Define `eval_writes(effect_expr, param_bindings) -> WritesEffect{kind, keys}`.
+
+Implementation in `engine/src/writes_effect.cpp`:
+
+```cpp
+WritesEffect eval_writes(const WritesEffectExpr& expr, const EffectGamma& gamma);
+```
 
 Rules (v1):
 
-- `EvalWrites(Keys{K...}, Γ) = Exact({K...})`.
+- `eval_writes(EffectKeys{K...}, _) = Exact({K...})` (sorted + deduped)
 
-- `EvalWrites(FromParam(p), Γ)`:
-  - if Γ binds param `p` to a concrete key_id (or finite list via FromPath): `Exact({key_id...})`
-  - else `Unknown` (unless a bounded domain is explicitly enumerated, in which case `May(union(domain))` is permitted by policy).
+- `eval_writes(EffectFromParam{p}, gamma)`:
+  - if gamma binds `p` to a `uint32_t` key_id: `Exact({key_id})`
+  - else: `Unknown`
 
-- `EvalWrites(SwitchEnum(param, cases), Γ)`:
-  - if Γ binds `param` to a concrete enum value `v` and `v ∈ cases`: `Exact(keys(cases[v]))`
-  - else if `param` is not constant but its domain is a finite enum and `cases` covers the full domain: `May(union over cases)`
-  - else `Unknown`.
+- `eval_writes(EffectSwitchEnum{param, cases}, gamma)`:
+  - if gamma binds `param` to a `std::string v` and `v ∈ cases`: eval the selected case
+  - else if all cases are Exact: `May(union over all case keys)`
+  - else: `Unknown`
 
-- `EvalWrites(Union([e1..en]), Γ)`:
-  - evaluate each `ri = EvalWrites(ei, Γ)`
-  - if any `ri = Unknown`: result is `Unknown`
-  - else if all are `Exact`: `Exact(union(keys(ri)))`
-  - else: `May(union(keys(ri)))`
+- `eval_writes(EffectUnion{items}, gamma)`:
+  - evaluate each `ri = eval_writes(items[i], gamma)`
+  - if any `ri.kind = Unknown`: result is `Unknown`
+  - else if all are `Exact`: `Exact(union(keys))`
+  - else: `May(union(keys))`
+
+All result keys are sorted and deduplicated.
 
 ### 6.2 Policy: where `May` / `Unknown` are acceptable
 The system must distinguish contexts:
@@ -218,7 +290,13 @@ The system must distinguish contexts:
 ## 7. Subgraph aggregation rules
 
 ### 7.1 Node-level effects
-Each node has a `writes_effect(node, Γ)` derived by evaluating the TaskSpec writes expression with node params under Γ.
+Each node's `writes_eval` is computed during `validate_plan()`:
+
+1. `validate_params(node.op, node.params)` → `ValidatedParams` (with defaults + normalization)
+2. `build_param_bindings(validated_params)` → `EffectGamma`
+3. `compute_effective_writes(spec)` → `WritesEffectExpr` (union of `.writes` and `.writes_effect`)
+4. `eval_writes(expr, param_bindings)` → `WritesEffect{kind, keys}`
+5. Store in `node.writes_eval_kind` and `node.writes_eval_keys`
 
 ### 7.2 Subgraph writes
 For a subgraph `S` containing nodes `{n1..nk}`, define:
@@ -340,3 +418,178 @@ Without `cap.rfc.0005...` required:
 - OQ1: Formalize `reads_exact` / `reads_may` similarly (especially for ExprIR/PredIR references).
 - OQ2: Extend effect language with bounded `FromPath` for common map/list patterns (extract_features).
 - OQ3: Formalize rowset mutation effects and merge semantics for future control-flow features.
+
+---
+
+## 15. Implementation Status (Steps 12.1-12.3)
+
+This section documents the actual implementation as of 2026-01-18.
+
+### 15.1 Capability Registration (Step 12.1)
+
+The capability is registered in `registry/capabilities.toml`:
+
+```toml
+[[capability]]
+id = "cap.rfc.0005.key_effects_writes_exact.v1"
+rfc = "0005"
+name = "key_effects_writes_exact"
+status = "implemented"
+doc = "Key effect inference and writes_exact enforcement for branching meta-tasks"
+payload_schema = '''
+{
+  "type": "object",
+  "additionalProperties": false
+}
+'''
+```
+
+### 15.2 Writes Contract Design (Step 12.2)
+
+The implementation uses a **unified Writes Contract** model:
+
+```
+Writes Contract = UNION( Keys(writes), writes_effect )
+```
+
+| Field | Purpose | When to Use |
+|-------|---------|-------------|
+| `writes` | Fixed/static key IDs | Task always writes the same columns |
+| `writes_effect` | Dynamic/param-dependent | Columns depend on params |
+
+**Key insight:** Most tasks only fill ONE field:
+- Source tasks with fixed schema → use `.writes`
+- Row-only ops (filter, take) → both empty
+- Param-dependent ops (vm) → use `.writes_effect`
+
+#### TaskSpec Fields
+
+```cpp
+struct TaskSpec {
+  // ... other fields ...
+  std::vector<KeyId> writes;                     // Static/fixed key writes
+  std::optional<WritesEffectExpr> writes_effect; // Dynamic/param-dependent
+};
+```
+
+#### Effect Expression Types (`engine/include/writes_effect.h`)
+
+```cpp
+// Keys{key_ids} → always Exact({keys})
+struct EffectKeys { std::vector<uint32_t> key_ids; };
+
+// FromParam("out") → Exact if param constant, else Unknown
+struct EffectFromParam { std::string param; };
+
+// SwitchEnum(param, cases) → Exact if param constant, May if bounded, else Unknown
+struct EffectSwitchEnum {
+  std::string param;
+  std::map<std::string, std::shared_ptr<WritesEffectExpr>> cases;
+};
+
+// Union([e1, e2, ...]) → combines effects
+struct EffectUnion { std::vector<std::shared_ptr<WritesEffectExpr>> items; };
+
+using WritesEffectExpr = std::variant<EffectKeys, EffectFromParam, EffectSwitchEnum, EffectUnion>;
+```
+
+#### Helper Function
+
+`compute_effective_writes(spec)` computes the union automatically:
+- If only `.writes` → `EffectKeys{writes}`
+- If only `.writes_effect` → `*writes_effect`
+- If both → `EffectUnion{Keys(writes), *writes_effect}`
+- If neither → `EffectKeys{}` (empty, no writes)
+
+### 15.3 Engine Evaluation (Step 12.3a)
+
+The engine evaluates the writes contract **per-node at plan-load time** during `validate_plan()`.
+
+#### Node Struct Fields
+
+```cpp
+struct Node {
+  // ... existing fields ...
+
+  // RFC0005: Evaluated writes contract (populated during validation)
+  EffectKind writes_eval_kind = EffectKind::Unknown;
+  std::vector<uint32_t> writes_eval_keys;  // sorted, deduped; empty for Unknown
+};
+```
+
+#### Evaluation Flow
+
+1. `validate_plan(plan)` iterates over nodes
+2. For each node:
+   - `validate_params()` returns `ValidatedParams` (with defaults + type normalization)
+   - `build_param_bindings(validated_params)` extracts Int/String params as `EffectGamma`
+   - `compute_effective_writes(spec)` combines `.writes` and `.writes_effect`
+   - `eval_writes(expr, param_bindings)` evaluates to `WritesEffect{kind, keys}`
+   - Result stored in `node.writes_eval_kind` and `node.writes_eval_keys`
+
+#### CLI Output (`--print-plan-info`)
+
+```bash
+engine/bin/rankd --print-plan-info --plan_name reels_plan_a
+```
+
+Output (JSON):
+```json
+{
+  "plan_name": "reels_plan_a",
+  "capabilities_required": [],
+  "capabilities_digest": "",
+  "nodes": [
+    {"node_id": "n0", "op": "viewer.follow", "writes_eval": {"kind": "Exact", "keys": [3001, 3002]}},
+    {"node_id": "n1", "op": "vm", "writes_eval": {"kind": "Exact", "keys": [2001]}},
+    {"node_id": "n2", "op": "filter", "writes_eval": {"kind": "Exact", "keys": []}},
+    {"node_id": "n3", "op": "take", "writes_eval": {"kind": "Exact", "keys": []}}
+  ]
+}
+```
+
+For plans with unsupported capabilities, `--print-plan-info` returns exit code 1 with structured error:
+```json
+{
+  "error": {
+    "code": "UNSUPPORTED_CAPABILITY",
+    "unsupported": ["cap.foo.v1"]
+  }
+}
+```
+
+### 15.4 Tests (Step 12.3b)
+
+Test fixtures in `engine/tests/fixtures/plan_info/`:
+- `vm_and_row_ops.plan.json` - vm with out_key, filter, take
+- `fixed_source.plan.json` - viewer.fetch_cached_recommendation
+
+Catch2 tests in `engine/tests/test_plan_info_writes_eval.cpp`:
+- vm node: Exact + includes out_key
+- filter/take/concat: Exact + empty keys
+- Source tasks: Exact + includes fixed writes
+- All keys sorted and unique
+
+CI integration tests 55-56 verify CLI output.
+
+### 15.5 Key Differences from RFC Proposal
+
+| RFC Proposal | Actual Implementation |
+|--------------|----------------------|
+| `key_effects` field in artifact JSON | Evaluated at plan-load time, stored in Node struct |
+| Lowercase kind: `"exact"`, `"may"` | PascalCase: `"Exact"`, `"May"`, `"Unknown"` |
+| Compiler emits metadata | Engine computes during `validate_plan()` |
+| Separate `writes` expression | Unified: `UNION(writes, writes_effect)` |
+
+### 15.6 Files
+
+| Component | Location |
+|-----------|----------|
+| Capability registry | `registry/capabilities.toml` |
+| Effect types | `engine/include/writes_effect.h` |
+| Effect evaluator | `engine/src/writes_effect.cpp` |
+| TaskSpec with writes | `engine/include/task_registry.h` |
+| Plan validation | `engine/src/executor.cpp` |
+| CLI output | `engine/src/main.cpp` |
+| Task guide | `docs/TASK_IMPLEMENTATION_GUIDE.md` |
+| Tests | `engine/tests/test_plan_info_writes_eval.cpp` |

--- a/scripts/ci.sh
+++ b/scripts/ci.sh
@@ -65,6 +65,7 @@ run_bg "Unit tests (rankd)" engine/bin/rankd_tests
 run_bg "Unit tests (concat)" engine/bin/concat_tests
 run_bg "Unit tests (regex)" engine/bin/regex_tests
 run_bg "Unit tests (writes_effect)" engine/bin/writes_effect_tests
+run_bg "Unit tests (plan_info)" engine/bin/plan_info_tests
 run_bg "TS writes_effect tests" ./node_modules/.bin/tsx dsl/tools/test_writes_effect.ts
 wait_all
 


### PR DESCRIPTION
## Summary
Add regression tests that freeze the writes_eval behavior from Step 12.3a, plus comprehensive RFC 0005 update.

### Fixtures
| Fixture | Purpose |
|---------|---------|
| `engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json` | vm with out_key (FromParam), filter, take (row-only ops) |
| `engine/tests/fixtures/plan_info/fixed_source.plan.json` | viewer.fetch_cached_recommendation (fixed-writes source) |

### Catch2 Tests (`test_plan_info_writes_eval.cpp`)
- **vm node**: Exact + includes out_key (2001 = final_score)
- **filter/take/concat**: Exact + empty keys (row-only ops)
- **viewer.follow**: Exact + includes country (3001) and title (3002)
- **viewer.fetch_cached_recommendation**: Exact + includes country (3001)
- **All keys**: sorted and unique invariant

### RFC 0005 Update (Comprehensive)
Updated core RFC sections to match actual implementation:
- **Status**: Draft → Implemented
- **Section 4.5**: Changed from "artifact metadata" to "engine-evaluated writes_eval"
- **Section 5.2**: Two-field Writes Contract design (`writes` + `writes_effect`)
- **Section 5.3**: Effect expression forms (EffectKeys, EffectFromParam, etc.)
- **Section 5.4**: `compute_effective_writes()` helper
- **Section 6.1**: `param_bindings` from `ValidatedParams` (renamed from Γ)
- **Section 6.2**: `eval_writes()` evaluation rules
- **Section 7.1**: Node-level evaluation flow during `validate_plan()`
- **Section 15**: Implementation status details

## Manual verification
```bash
engine/bin/rankd --print-plan-info --plan engine/tests/fixtures/plan_info/vm_and_row_ops.plan.json | jq '.nodes[] | {op, writes_eval}'
engine/bin/rankd --print-plan-info --plan engine/tests/fixtures/plan_info/fixed_source.plan.json | jq '.nodes[] | {op, writes_eval}'
```

## Test plan
- [x] CI passes (all 56 tests + new plan_info_tests)
- [x] `engine/bin/plan_info_tests` passes (40 assertions in 3 test cases)

🤖 Generated with [Claude Code](https://claude.ai/code)
