### PR TITLE
Visualizer Step 5: Registry viewer & edit existing plan

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -701,7 +701,7 @@ See [docs/IMPLEMENTATION_PROGRESS.md](docs/IMPLEMENTATION_PROGRESS.md) for detai
 - Tasks: viewer.follow, vm, filter, take, concat, sort
 - Capabilities system (RFC 0001), writes_effect (RFC 0005)
 - AST extraction for natural expressions and predicates
-- Visualizer with live plan editing
+- Visualizer with live plan editing, registry browser, and edit existing plan support
 - Endpoint Registry with per-env config, EndpointRef param type
 
 **🔲 Remaining:**

--- a/artifacts/tasks.json
+++ b/artifacts/tasks.json
@@ -1,0 +1,147 @@
+{
+  "schema_version": 1,
+  "tasks": [
+    {
+      "op": "concat",
+      "output_pattern": "ConcatDense",
+      "params": [
+        {
+          "name": "rhs",
+          "type": "node_ref",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "filter",
+      "output_pattern": "StableFilter",
+      "params": [
+        {
+          "name": "pred_id",
+          "type": "pred_id",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "sort",
+      "output_pattern": "PermutationOfInput",
+      "params": [
+        {
+          "name": "by",
+          "type": "int",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "order",
+          "type": "string",
+          "required": false,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "take",
+      "output_pattern": "PrefixOfInput",
+      "params": [
+        {
+          "name": "count",
+          "type": "int",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "viewer.fetch_cached_recommendation",
+      "output_pattern": "SourceFanoutDense",
+      "params": [
+        {
+          "name": "fanout",
+          "type": "int",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "viewer.follow",
+      "output_pattern": "SourceFanoutDense",
+      "params": [
+        {
+          "name": "fanout",
+          "type": "int",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ]
+    },
+    {
+      "op": "vm",
+      "output_pattern": "UnaryPreserveView",
+      "params": [
+        {
+          "name": "expr_id",
+          "type": "expr_id",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "out_key",
+          "type": "int",
+          "required": true,
+          "nullable": false
+        },
+        {
+          "name": "trace",
+          "type": "string",
+          "required": false,
+          "nullable": true
+        }
+      ],
+      "writes_effect": {
+        "kind": "FromParam",
+        "param": "out_key"
+      }
+    }
+  ]
+}

--- a/dsl/src/codegen.ts
+++ b/dsl/src/codegen.ts
@@ -102,6 +102,9 @@ function main() {
   const testEndpointsJson = buildEndpointJson(endpoints.test, "test");
   const prodEndpointsJson = buildEndpointJson(endpoints.prod, "prod");
 
+  // Build tasks canonical JSON
+  const tasksCanonical = { schema_version: 1, tasks: tasks.tasks };
+
   // Generate all outputs
   const outputs: Array<{ path: string; content: string }> = [
     // Artifacts JSON
@@ -113,6 +116,7 @@ function main() {
     { path: "artifacts/endpoints.dev.json", content: JSON.stringify(devEndpointsJson, null, 2) + "\n" },
     { path: "artifacts/endpoints.test.json", content: JSON.stringify(testEndpointsJson, null, 2) + "\n" },
     { path: "artifacts/endpoints.prod.json", content: JSON.stringify(prodEndpointsJson, null, 2) + "\n" },
+    { path: "artifacts/tasks.json", content: JSON.stringify(tasksCanonical, null, 2) + "\n" },
     // Artifacts digests
     { path: "artifacts/keys.digest", content: keysDigest + "\n" },
     { path: "artifacts/params.digest", content: paramsDigest + "\n" },

--- a/tools/visualizer/CLAUDE.md
+++ b/tools/visualizer/CLAUDE.md
@@ -109,7 +109,33 @@ pnpm -C tools/visualizer run test:headed   # Run tests in headed browser
 - Simple home page when no plan loaded
 - E2E tests for panel interactions
 
-### Step 03: Fragment Support (Next) 🔲
+### Step 03: Registry Viewer & Edit Existing Plan ✅
+
+**Registry Viewer**
+- Browse Keys, Params, Features, Capabilities, Tasks
+- Tabbed interface with search/filter
+- Status badges (active=green, deprecated=yellow, blocked=red)
+- Clickable cross-references in Details panel (`Key[3001]` → registry entry)
+- Multiple draggable detail panels
+- URL persistence (`?view=registries&tab=keys&selected=3001`)
+
+**Edit Existing Plan**
+- "Edit" button on plan cards in home page
+- "Edit" button in canvas toolbar when viewing a plan
+- Loads plan source into editor for modification
+- Only shows Edit in view mode (hidden in edit mode)
+
+**Navbar**
+- Editor / Plans / Registries navigation tabs
+- Active tab highlighted
+- Replaces "Back to Home" button
+
+**Polish**
+- Project folder indicator in header
+- Fixed Fit button to use container dimensions
+- E2E tests for edit plan flow
+
+### Step 04: Fragment Support 🔲
 
 - Detect fragment boundaries in plan
 - Render fragments as collapsible supernodes
@@ -117,14 +143,14 @@ pnpm -C tools/visualizer run test:headed   # Run tests in headed browser
 - Auto-collapse when visible nodes > threshold
 - LRU eviction for expanded fragments
 
-### Step 04: Enhanced UX 🔲
+### Step 05: Enhanced UX 🔲
 
 - Keyboard shortcuts (Escape=deselect, +/-=zoom, F=fit)
 - Minimap for large graphs
 - Search/filter nodes
 - Export as PNG/SVG
 
-### Step 05: Production 🔲
+### Step 06: Production 🔲
 
 - Production build optimization
 - Deploy to GitHub Pages or similar
@@ -149,9 +175,10 @@ tools/visualizer/
 │   │   ├── EditorPanel.tsx   # Monaco editor with live compilation
 │   │   ├── MenuBar.tsx       # Add/View dropdown menus
 │   │   ├── Modal.tsx         # PromptModal and ConfirmModal
-│   │   ├── PlanSelector.tsx  # Plan list from index.json + drag-drop
+│   │   ├── PlanSelector.tsx  # Plan list from index.json + drag-drop + edit buttons
+│   │   ├── RegistryViewer.tsx # Registry browser (keys, params, features, etc.)
 │   │   ├── SourcePanel.tsx   # Original .plan.ts source viewer
-│   │   ├── Toolbar.tsx       # Floating toolbar (stats + fit button)
+│   │   ├── Toolbar.tsx       # Floating toolbar (stats + fit + edit buttons)
 │   │   └── ui/
 │   │       └── Button.tsx    # Reusable button component
 │   ├── layout/
@@ -163,7 +190,8 @@ tools/visualizer/
 │       └── preferences.ts    # Centralized localStorage module
 ├── e2e/
 │   ├── editor.spec.ts        # Editor e2e tests
-│   └── dockview.spec.ts      # Panel layout e2e tests
+│   ├── dockview.spec.ts      # Panel layout e2e tests
+│   └── edit-plan.spec.ts     # Edit existing plan + navbar tests
 ├── playwright.config.ts      # Playwright configuration
 ├── vite.config.ts            # Vite config + middlewares
 └── index.html
@@ -219,6 +247,31 @@ tools/visualizer/
 - Floating toolbar at bottom center of canvas
 - Shows node/edge count
 - Fit button to auto-fit graph to view
+- Edit button (view mode only) to edit current plan's source
+
+### Edit Existing Plan
+- **From home page**: Click "Edit" button on any plan card
+- **From plan view**: Click "Edit" button in canvas toolbar
+- Loads the plan's `.plan.ts` source into the editor
+- Edit button only appears when source is available
+- Edit button hidden in edit mode (already editing)
+
+### Registry Viewer
+- Access via "Registries" nav tab or "Browse Registries" card
+- Tabbed interface: Keys, Params, Features, Capabilities, Tasks
+- Color-coded tabs (blue=keys, orange=params, green=features, etc.)
+- Search/filter across name and documentation
+- Status badges: active (green), deprecated (yellow), blocked (red)
+- Click row to open draggable detail panel
+- Multiple detail panels can be open simultaneously
+- Cross-references from Details panel (`Key[3001]`) link to registry
+
+### Navbar
+- Three tabs: Editor, Plans, Registries
+- Active tab highlighted
+- Editor: Opens live plan editor
+- Plans: Shows plan selector (home page)
+- Registries: Opens registry viewer
 
 ### Live Plan Editor (Step 01)
 - Click "Create New Plan" to open editor panel

--- a/tools/visualizer/e2e/dockview.spec.ts
+++ b/tools/visualizer/e2e/dockview.spec.ts
@@ -132,12 +132,12 @@ test.describe('Dockview Panel Layout', () => {
     await expect(page.locator('.dv-tab:has-text("Details")')).toBeVisible();
   });
 
-  test('Back to Plans button returns to home page', async ({ page }) => {
+  test('Plans nav button returns to home page', async ({ page }) => {
     await page.click('text=Create New Plan');
     await expect(page.locator('.dv-dockview')).toBeVisible();
 
-    // Click Back to Plans
-    await page.click('text=← Back to Plans');
+    // Click Plans in navbar
+    await page.click('nav button:has-text("Plans")');
 
     // Should be back at home page
     await expect(page.locator('text=Create New Plan')).toBeVisible();
@@ -246,10 +246,11 @@ test.describe('Dockview Panel Interactions', () => {
       }
     }
 
-    // Reopen all via Add menu
+    // Reopen all via Add menu (use menu item selector to avoid matching navbar)
     for (const panelName of ['Editor', 'Canvas', 'Details']) {
       await page.click('button:has-text("Add")');
-      await page.click(`text=${panelName}`);
+      // Click the menu item specifically (last button with that text, since menu items come after nav)
+      await page.locator(`button:has-text("${panelName}")`).last().click();
       await expect(page.locator(`.dv-tab:has-text("${panelName}")`)).toBeVisible();
     }
   });

--- a/tools/visualizer/e2e/edit-plan.spec.ts
+++ b/tools/visualizer/e2e/edit-plan.spec.ts
@@ -1,0 +1,156 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Edit Existing Plan', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.reload();
+  });
+
+  test('plan cards show Edit button', async ({ page }) => {
+    // Wait for plans to load
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+
+    // Each plan card should have an Edit button
+    const editButtons = page.locator('button:has-text("Edit")');
+    await expect(editButtons.first()).toBeVisible();
+  });
+
+  test('clicking Edit on plan card opens editor with source', async ({ page }) => {
+    // Wait for plans to load
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+
+    // Click Edit on the first plan (reels_plan_a or similar)
+    await page.locator('button:has-text("Edit")').first().click();
+
+    // Should be in edit mode with editor visible
+    await expect(page.locator('.dv-tab:has-text("Editor")')).toBeVisible();
+
+    // Editor should contain plan code (not the default template)
+    // The source should have definePlan and the actual plan name
+    await expect(page.locator('.monaco-editor .view-lines')).toContainText('definePlan');
+  });
+
+  test('Edit button in toolbar appears when viewing plan with source', async ({ page }) => {
+    // Click on a plan to view it
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+
+    // Click on the plan name (not the Edit button) to view it
+    await page.locator('span:has-text("reels_plan_a")').first().click();
+
+    // Wait for plan to load and canvas to render
+    await expect(page.locator('.dv-tab:has-text("Canvas")')).toBeVisible();
+
+    // Toolbar should show Edit button (use exact match to avoid matching "Editor")
+    await expect(page.getByRole('button', { name: 'Edit', exact: true })).toBeVisible();
+  });
+
+  test('clicking Edit in toolbar opens editor with current plan source', async ({ page }) => {
+    // View a plan first
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+    await page.locator('span:has-text("reels_plan_a")').first().click();
+    await expect(page.locator('.dv-tab:has-text("Canvas")')).toBeVisible();
+
+    // Click Edit in toolbar (use exact match to avoid matching "Editor")
+    await page.getByRole('button', { name: 'Edit', exact: true }).click();
+
+    // Should now be in edit mode
+    await expect(page.locator('.dv-tab:has-text("Editor")')).toBeVisible();
+
+    // Editor should have the plan source
+    await expect(page.locator('.monaco-editor .view-lines')).toContainText('definePlan');
+    await expect(page.locator('.monaco-editor .view-lines')).toContainText('reels_plan_a');
+  });
+
+  test('Edit button not shown in edit mode', async ({ page }) => {
+    // Enter edit mode via Create New Plan
+    await page.click('text=Create New Plan');
+    await expect(page.locator('.dv-tab:has-text("Editor")')).toBeVisible();
+
+    // Compile a plan so toolbar appears
+    await expect(page.locator('button:has-text("Compile & Visualize")')).toBeEnabled({ timeout: 30000 });
+    await page.click('text=Compile & Visualize');
+    await expect(page.locator('text=Compiled successfully')).toBeVisible({ timeout: 30000 });
+
+    // Toolbar should show Fit but NOT Edit (we're already editing)
+    await expect(page.locator('button:has-text("Fit")')).toBeVisible();
+
+    // Edit button should not be in the toolbar
+    // The toolbar has buttons, check that Edit is not among them
+    const toolbarEditButton = page.locator('[style*="bottom: 16px"] button:has-text("Edit")');
+    await expect(toolbarEditButton).not.toBeVisible();
+  });
+});
+
+test.describe('Navbar Navigation', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.reload();
+  });
+
+  test('navbar has Editor, Plans, and Registries tabs', async ({ page }) => {
+    await expect(page.locator('nav button:has-text("Editor")')).toBeVisible();
+    await expect(page.locator('nav button:has-text("Plans")')).toBeVisible();
+    await expect(page.locator('nav button:has-text("Registries")')).toBeVisible();
+  });
+
+  test('clicking Editor tab opens editor', async ({ page }) => {
+    await page.click('nav button:has-text("Editor")');
+
+    // Should show editor panel
+    await expect(page.locator('.dv-tab:has-text("Editor")')).toBeVisible();
+  });
+
+  test('clicking Plans tab shows plan selector', async ({ page }) => {
+    // First go to editor
+    await page.click('nav button:has-text("Editor")');
+    await expect(page.locator('.dv-tab:has-text("Editor")')).toBeVisible();
+
+    // Click Plans to go back
+    await page.click('nav button:has-text("Plans")');
+
+    // Should see plan selector
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+  });
+
+  test('clicking Registries tab shows registry viewer', async ({ page }) => {
+    await page.click('nav button:has-text("Registries")');
+
+    // Should show registry tabs
+    await expect(page.locator('button:has-text("Keys")')).toBeVisible();
+    await expect(page.locator('button:has-text("Params")')).toBeVisible();
+    await expect(page.locator('button:has-text("Features")')).toBeVisible();
+  });
+});
+
+test.describe('Canvas Toolbar', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.evaluate(() => {
+      localStorage.clear();
+    });
+    await page.reload();
+  });
+
+  test('Fit button centers the graph', async ({ page }) => {
+    // View a plan
+    await expect(page.locator('text=Available Plans')).toBeVisible();
+    await page.locator('span:has-text("reels_plan_a")').first().click();
+    await expect(page.locator('.dv-tab:has-text("Canvas")')).toBeVisible();
+
+    // Wait for canvas to render
+    await page.waitForTimeout(500);
+
+    // Click Fit button
+    await page.click('button:has-text("Fit")');
+
+    // The graph should be visible (canvas has nodes)
+    // We can't easily verify centering, but we can verify the button works without error
+    await expect(page.locator('button:has-text("Fit")')).toBeVisible();
+  });
+});

--- a/tools/visualizer/src/App.tsx
+++ b/tools/visualizer/src/App.tsx
@@ -1,7 +1,8 @@
-import { useState, useCallback, useRef } from 'react';
+import { useState, useCallback, useRef, useEffect } from 'react';
 import { useStore } from './state/store';
 import DockLayout, { DockLayoutHandle } from './components/DockLayout';
 import PlanSelector from './components/PlanSelector';
+import RegistryViewer from './components/RegistryViewer';
 import MenuBar from './components/MenuBar';
 
 import { dracula } from './theme';
@@ -55,25 +56,156 @@ const styles: Record<string, React.CSSProperties> = {
     color: dracula.comment,
     transition: 'all 0.2s',
   },
+  projectPath: {
+    fontSize: '10px',
+    color: dracula.comment,
+    opacity: 0.6,
+    fontFamily: 'ui-monospace, monospace',
+    marginLeft: '12px',
+    padding: '2px 6px',
+    background: dracula.currentLine,
+    borderRadius: '3px',
+  },
+  navbar: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '2px',
+    marginLeft: '24px',
+    padding: '2px',
+    background: dracula.currentLine,
+    borderRadius: '6px',
+  },
+  navItem: {
+    padding: '6px 14px',
+    fontSize: '12px',
+    fontWeight: 500,
+    color: dracula.comment,
+    background: 'transparent',
+    border: 'none',
+    borderRadius: '4px',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+  },
+  navItemActive: {
+    background: dracula.background,
+    color: dracula.foreground,
+    boxShadow: '0 1px 2px rgba(0,0,0,0.1)',
+  },
 };
+
+type AppView = 'home' | 'plan' | 'registries';
 
 export default function App() {
   const fileName = useStore((s) => s.fileName);
   const planJson = useStore((s) => s.planJson);
+  const sourceCode = useStore((s) => s.sourceCode);
   const clearPlan = useStore((s) => s.clearPlan);
+  const loadRegistries = useStore((s) => s.loadRegistries);
+  const registries = useStore((s) => s.registries);
+  const setEditSourceCode = useStore((s) => s.setEditSourceCode);
 
   const [mode, setMode] = useState<'view' | 'edit'>('view');
+  const [currentView, setCurrentView] = useState<AppView>('home');
   const [existingPanels, setExistingPanels] = useState<Set<string>>(new Set());
   const dockLayoutRef = useRef<DockLayoutHandle>(null);
 
+  // Check URL on mount and handle popstate for registry view
+  useEffect(() => {
+    const updateViewFromUrl = () => {
+      const params = new URLSearchParams(window.location.search);
+      if (params.get('view') === 'registries') {
+        setCurrentView('registries');
+      } else if (params.get('plan')) {
+        setCurrentView('plan');
+      } else {
+        setCurrentView('home');
+      }
+    };
+
+    // Initial check
+    updateViewFromUrl();
+
+    // Listen for popstate (browser back/forward)
+    const handlePopState = () => {
+      updateViewFromUrl();
+    };
+
+    window.addEventListener('popstate', handlePopState);
+    return () => window.removeEventListener('popstate', handlePopState);
+  }, []);
+
+  // Sync view state with plan changes
+  useEffect(() => {
+    if (planJson) {
+      setCurrentView('plan');
+    }
+  }, [planJson]);
+
   const handleGoHome = useCallback(() => {
     clearPlan();
+    setEditSourceCode(null);
     setMode('view');
-  }, [clearPlan]);
+    setCurrentView('home');
+    // Update URL
+    history.pushState({}, '', window.location.pathname);
+  }, [clearPlan, setEditSourceCode]);
 
   const handleCreateNew = useCallback(() => {
+    setEditSourceCode(null);
     setMode('edit');
-  }, []);
+    setCurrentView('plan');
+  }, [setEditSourceCode]);
+
+  // Edit current plan (from toolbar when viewing a plan)
+  const handleEditCurrent = useCallback(() => {
+    if (sourceCode) {
+      setEditSourceCode(sourceCode);
+      setMode('edit');
+      setCurrentView('plan');
+    }
+  }, [sourceCode, setEditSourceCode]);
+
+  // Edit a plan by name (from PlanSelector)
+  const handleEditPlanByName = useCallback(async (planName: string) => {
+    // Fetch the source code directly
+    try {
+      const resp = await fetch(`/sources/${planName}.plan.ts`);
+      if (resp.ok) {
+        const code = await resp.text();
+        setEditSourceCode(code);
+        setMode('edit');
+        setCurrentView('plan');
+      } else {
+        // No source available, just open editor with default
+        setEditSourceCode(null);
+        setMode('edit');
+        setCurrentView('plan');
+      }
+    } catch {
+      setEditSourceCode(null);
+      setMode('edit');
+      setCurrentView('plan');
+    }
+  }, [setEditSourceCode]);
+
+  const handleBrowseRegistries = useCallback(() => {
+    clearPlan();
+    setMode('view');
+    setCurrentView('registries');
+    if (!registries) {
+      loadRegistries();
+    }
+    // Update URL
+    history.pushState({ view: 'registries' }, '', '?view=registries&tab=keys');
+  }, [clearPlan, loadRegistries, registries]);
+
+  const handleBrowsePlans = useCallback(() => {
+    clearPlan();
+    setMode('view');
+    setCurrentView('home');
+    // Update URL
+    history.pushState({}, '', window.location.pathname);
+  }, [clearPlan]);
 
   const handleAddPanel = useCallback((panel: 'editor' | 'canvas' | 'details' | 'source') => {
     dockLayoutRef.current?.addPanel(panel);
@@ -87,8 +219,13 @@ export default function App() {
     setExistingPanels(panels);
   }, []);
 
-  // Show simple home page when in view mode with no plan
-  const showHomePage = mode === 'view' && !planJson;
+  // Show simple home page when in view mode with no plan and not in registries view
+  const showHomePage = currentView === 'home' && mode === 'view' && !planJson;
+  const showRegistries = currentView === 'registries';
+  const showPlanView = !showHomePage && !showRegistries;
+
+  // Determine which nav item is active
+  const activeNav = showRegistries ? 'registries' : mode === 'edit' ? 'editor' : 'plans';
 
   return (
     <div style={styles.container}>
@@ -102,9 +239,65 @@ export default function App() {
           >
             Plan Visualizer
           </span>
+          <span style={styles.projectPath} title={__PROJECT_ROOT__}>
+            {__PROJECT_NAME__}
+          </span>
+
+          {/* Navigation Bar */}
+          <nav style={styles.navbar}>
+            <button
+              style={{
+                ...styles.navItem,
+                ...(activeNav === 'editor' ? styles.navItemActive : {}),
+              }}
+              onClick={handleCreateNew}
+              onMouseEnter={(e) => {
+                if (activeNav !== 'editor') e.currentTarget.style.color = dracula.foreground;
+              }}
+              onMouseLeave={(e) => {
+                if (activeNav !== 'editor') e.currentTarget.style.color = dracula.comment;
+              }}
+            >
+              Editor
+            </button>
+            <button
+              style={{
+                ...styles.navItem,
+                ...(activeNav === 'plans' ? styles.navItemActive : {}),
+              }}
+              onClick={handleBrowsePlans}
+              onMouseEnter={(e) => {
+                if (activeNav !== 'plans') e.currentTarget.style.color = dracula.foreground;
+              }}
+              onMouseLeave={(e) => {
+                if (activeNav !== 'plans') e.currentTarget.style.color = dracula.comment;
+              }}
+            >
+              Plans
+            </button>
+            <button
+              style={{
+                ...styles.navItem,
+                ...(activeNav === 'registries' ? styles.navItemActive : {}),
+              }}
+              onClick={handleBrowseRegistries}
+              onMouseEnter={(e) => {
+                if (activeNav !== 'registries') e.currentTarget.style.color = dracula.foreground;
+              }}
+              onMouseLeave={(e) => {
+                if (activeNav !== 'registries') e.currentTarget.style.color = dracula.comment;
+              }}
+            >
+              Registries
+            </button>
+          </nav>
+
+          {/* Context info */}
           {fileName && <span style={styles.fileName}>{fileName}</span>}
           {mode === 'edit' && !fileName && <span style={styles.fileName}>New Plan</span>}
-          {!showHomePage && (
+
+          {/* Menu bar for plan view */}
+          {showPlanView && (
             <MenuBar
               onAddPanel={handleAddPanel}
               onResetLayout={handleResetLayout}
@@ -113,28 +306,23 @@ export default function App() {
             />
           )}
         </div>
-        {(mode === 'edit' || planJson) && (
-          <button
-            style={styles.backButton}
-            onClick={handleGoHome}
-            onMouseEnter={(e) => {
-              e.currentTarget.style.borderColor = dracula.purple;
-              e.currentTarget.style.color = dracula.foreground;
-            }}
-            onMouseLeave={(e) => {
-              e.currentTarget.style.borderColor = dracula.border;
-              e.currentTarget.style.color = dracula.comment;
-            }}
-          >
-            ← Back to Plans
-          </button>
-        )}
       </header>
       <main style={styles.main}>
-        {showHomePage ? (
-          <PlanSelector onCreateNew={handleCreateNew} />
-        ) : (
-          <DockLayout ref={dockLayoutRef} mode={mode} onPanelsChange={handlePanelsChange} />
+        {showHomePage && (
+          <PlanSelector
+            onCreateNew={handleCreateNew}
+            onBrowseRegistries={handleBrowseRegistries}
+            onEditPlan={handleEditPlanByName}
+          />
+        )}
+        {showRegistries && <RegistryViewer />}
+        {showPlanView && (
+          <DockLayout
+            ref={dockLayoutRef}
+            mode={mode}
+            onPanelsChange={handlePanelsChange}
+            onEdit={mode === 'view' ? handleEditCurrent : undefined}
+          />
         )}
       </main>
     </div>

--- a/tools/visualizer/src/components/EditorPanel.tsx
+++ b/tools/visualizer/src/components/EditorPanel.tsx
@@ -248,6 +248,18 @@ export default function EditorPanel() {
   const handleFormatRef = useRef<() => void>(() => {});
 
   const loadPlan = useStore((s) => s.loadPlan);
+  const editSourceCode = useStore((s) => s.editSourceCode);
+  const setEditSourceCode = useStore((s) => s.setEditSourceCode);
+
+  // Load source code from store if set (when editing existing plan)
+  useEffect(() => {
+    if (editSourceCode) {
+      setCode(editSourceCode);
+      setCurrentPlanId(null); // Not a saved plan, it's from the viewed plan
+      // Clear editSourceCode so it doesn't keep overwriting
+      setEditSourceCode(null);
+    }
+  }, [editSourceCode, setEditSourceCode]);
 
   // Save to localStorage on code change (debounced)
   useEffect(() => {

--- a/tools/visualizer/src/components/PlanSelector.tsx
+++ b/tools/visualizer/src/components/PlanSelector.tsx
@@ -5,6 +5,8 @@ import { dracula } from '../theme';
 
 interface PlanSelectorProps {
   onCreateNew?: () => void;
+  onBrowseRegistries?: () => void;
+  onEditPlan?: (planName: string) => void;
 }
 
 const styles: Record<string, React.CSSProperties> = {
@@ -34,7 +36,7 @@ const styles: Record<string, React.CSSProperties> = {
     gap: '24px',
     marginBottom: '32px',
     width: '100%',
-    maxWidth: '600px',
+    maxWidth: '900px',
   },
   optionCard: {
     flex: 1,
@@ -101,6 +103,21 @@ const styles: Record<string, React.CSSProperties> = {
     fontSize: '11px',
     color: dracula.comment,
   },
+  planActions: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  editButton: {
+    padding: '4px 8px',
+    background: 'transparent',
+    border: `1px solid ${dracula.border}`,
+    borderRadius: '4px',
+    color: dracula.comment,
+    fontSize: '11px',
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+  },
   divider: {
     display: 'flex',
     alignItems: 'center',
@@ -155,7 +172,7 @@ const styles: Record<string, React.CSSProperties> = {
   },
 };
 
-export default function PlanSelector({ onCreateNew }: PlanSelectorProps) {
+export default function PlanSelector({ onCreateNew, onBrowseRegistries, onEditPlan }: PlanSelectorProps) {
   const [isDragging, setIsDragging] = useState(false);
   const [localError, setLocalError] = useState<string | null>(null);
 
@@ -249,7 +266,7 @@ export default function PlanSelector({ onCreateNew }: PlanSelectorProps) {
       <div style={styles.title}>Plan Visualizer</div>
       <div style={styles.subtitle}>Explore and create ranking plans</div>
 
-      {/* Two main options */}
+      {/* Three main options */}
       <div style={styles.optionsRow}>
         <div
           style={styles.optionCard}
@@ -279,6 +296,25 @@ export default function PlanSelector({ onCreateNew }: PlanSelectorProps) {
             Select a plan from below<br />or drop a JSON file
           </span>
         </div>
+
+        <div
+          style={styles.optionCard}
+          onClick={onBrowseRegistries}
+          onMouseOver={(e) => {
+            e.currentTarget.style.borderColor = dracula.cyan;
+            e.currentTarget.style.background = dracula.selected;
+          }}
+          onMouseOut={(e) => {
+            e.currentTarget.style.borderColor = dracula.border;
+            e.currentTarget.style.background = dracula.currentLine;
+          }}
+        >
+          <span style={styles.optionIcon}>📋</span>
+          <span style={styles.optionTitle}>Browse Registries</span>
+          <span style={styles.optionDesc}>
+            Explore Keys, Params, Features,<br />Capabilities, and Tasks
+          </span>
+        </div>
       </div>
 
       {/* Existing plans section */}
@@ -289,11 +325,9 @@ export default function PlanSelector({ onCreateNew }: PlanSelectorProps) {
       ) : planIndex && planIndex.length > 0 ? (
         <div style={styles.planList}>
           {planIndex.map((plan) => (
-            <button
+            <div
               key={plan.name}
               style={styles.planButton}
-              onClick={() => loadPlanByName(plan.name)}
-              disabled={planLoading}
               onMouseOver={(e) => {
                 e.currentTarget.style.borderColor = dracula.purple;
                 e.currentTarget.style.background = dracula.selected;
@@ -303,9 +337,34 @@ export default function PlanSelector({ onCreateNew }: PlanSelectorProps) {
                 e.currentTarget.style.background = dracula.currentLine;
               }}
             >
-              <span style={styles.planName}>{plan.name}</span>
-              <span style={styles.planMeta}>{plan.built_by?.backend || 'unknown'}</span>
-            </button>
+              <span
+                style={{ ...styles.planName, flex: 1, cursor: 'pointer' }}
+                onClick={() => !planLoading && loadPlanByName(plan.name)}
+              >
+                {plan.name}
+              </span>
+              <div style={styles.planActions}>
+                <button
+                  style={styles.editButton}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onEditPlan?.(plan.name);
+                  }}
+                  disabled={planLoading}
+                  onMouseOver={(e) => {
+                    e.currentTarget.style.borderColor = dracula.green;
+                    e.currentTarget.style.color = dracula.green;
+                  }}
+                  onMouseOut={(e) => {
+                    e.currentTarget.style.borderColor = dracula.border;
+                    e.currentTarget.style.color = dracula.comment;
+                  }}
+                >
+                  Edit
+                </button>
+                <span style={styles.planMeta}>{plan.built_by?.backend || 'unknown'}</span>
+              </div>
+            </div>
           ))}
         </div>
       ) : null}

--- a/tools/visualizer/src/components/RegistryViewer.tsx
+++ b/tools/visualizer/src/components/RegistryViewer.tsx
@@ -1,0 +1,1200 @@
+import { useEffect, useCallback, useMemo, useState, useRef } from 'react';
+import { useStore } from '../state/store';
+import type { RegistryTab, EndpointEnv, KeyEntry, ParamEntry, FeatureEntry, CapabilityEntry, TaskEntry, EndpointEntry } from '../types';
+import { dracula } from '../theme';
+
+// Type for an open details panel
+interface OpenPanel {
+  id: string | number;
+  tab: RegistryTab;
+  x: number;
+  y: number;
+  zIndex: number;
+}
+
+const styles: Record<string, React.CSSProperties> = {
+  container: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: '100%',
+    height: '100%',
+    background: dracula.background,
+    overflow: 'hidden',
+  },
+  header: {
+    padding: '16px 24px',
+    borderBottom: `1px solid ${dracula.border}`,
+  },
+  searchRow: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '16px',
+    marginBottom: '16px',
+  },
+  searchInput: {
+    flex: 1,
+    maxWidth: '400px',
+    padding: '10px 14px',
+    border: `1px solid ${dracula.border}`,
+    borderRadius: '8px',
+    fontSize: '14px',
+    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+    background: dracula.background,
+    color: dracula.foreground,
+    outline: 'none',
+  },
+  tabBar: {
+    display: 'flex',
+    gap: '4px',
+  },
+  tab: {
+    padding: '8px 16px',
+    border: '1px solid transparent',
+    borderRadius: '6px',
+    background: dracula.currentLine,
+    color: dracula.comment,
+    fontSize: '13px',
+    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+  },
+  tabCount: {
+    fontSize: '11px',
+    opacity: 0.7,
+    fontWeight: 400,
+  },
+  content: {
+    flex: 1,
+    overflow: 'auto',
+    padding: '16px 24px',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+    fontSize: '13px',
+  },
+  th: {
+    textAlign: 'left',
+    padding: '10px 12px',
+    borderBottom: `2px solid ${dracula.border}`,
+    color: dracula.comment,
+    fontWeight: 600,
+    textTransform: 'uppercase',
+    fontSize: '11px',
+    letterSpacing: '0.5px',
+    cursor: 'pointer',
+    userSelect: 'none',
+    whiteSpace: 'nowrap',
+  },
+  td: {
+    padding: '10px 12px',
+    borderBottom: `1px solid ${dracula.border}`,
+    color: dracula.foreground,
+    verticalAlign: 'top',
+  },
+  tr: {
+    cursor: 'pointer',
+    transition: 'background 0.1s',
+  },
+  trSelected: {
+    background: dracula.selected,
+  },
+  statusBadge: {
+    display: 'inline-block',
+    padding: '2px 8px',
+    borderRadius: '4px',
+    fontSize: '11px',
+    fontWeight: 600,
+    textTransform: 'uppercase',
+  },
+  idCell: {
+    fontFamily: 'ui-monospace, monospace',
+    color: dracula.purple,
+    fontWeight: 500,
+  },
+  nameCell: {
+    fontFamily: 'ui-monospace, monospace',
+    fontWeight: 500,
+  },
+  typeCell: {
+    fontFamily: 'ui-monospace, monospace',
+    color: dracula.cyan,
+  },
+  docCell: {
+    color: dracula.comment,
+    maxWidth: '400px',
+  },
+  boolCell: {
+    fontFamily: 'ui-monospace, monospace',
+  },
+  loading: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '200px',
+    color: dracula.comment,
+    fontSize: '14px',
+  },
+  error: {
+    padding: '16px',
+    background: 'rgba(255, 85, 85, 0.1)',
+    border: `1px solid ${dracula.red}`,
+    borderRadius: '8px',
+    color: dracula.red,
+    fontSize: '14px',
+  },
+  emptyState: {
+    padding: '40px',
+    textAlign: 'center',
+    color: dracula.comment,
+    fontSize: '14px',
+  },
+  envSelector: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: '8px',
+    marginTop: '12px',
+  },
+  envLabel: {
+    fontSize: '12px',
+    color: dracula.comment,
+    fontWeight: 500,
+  },
+  envButtons: {
+    display: 'flex',
+    gap: '4px',
+  },
+  envButton: {
+    padding: '4px 12px',
+    border: `1px solid ${dracula.border}`,
+    borderRadius: '4px',
+    background: dracula.currentLine,
+    color: dracula.comment,
+    fontSize: '12px',
+    fontWeight: 500,
+    cursor: 'pointer',
+    transition: 'all 0.15s',
+  },
+  detailsPanel: {
+    position: 'fixed',
+    width: '320px',
+    maxHeight: 'calc(100vh - 120px)',
+    background: dracula.background,
+    border: `1px solid ${dracula.border}`,
+    borderRadius: '8px',
+    boxShadow: '0 4px 16px rgba(0, 0, 0, 0.15)',
+    overflow: 'auto',
+  },
+  detailsHeader: {
+    padding: '10px 12px',
+    borderBottom: `1px solid ${dracula.border}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    position: 'sticky',
+    top: 0,
+    background: dracula.background,
+    cursor: 'grab',
+    userSelect: 'none',
+  },
+  detailsHeaderDragging: {
+    cursor: 'grabbing',
+  },
+  detailsTitle: {
+    fontSize: '14px',
+    fontWeight: 600,
+    fontFamily: 'ui-monospace, monospace',
+  },
+  closeButton: {
+    padding: '4px 8px',
+    border: 'none',
+    background: 'transparent',
+    color: dracula.comment,
+    cursor: 'pointer',
+    fontSize: '16px',
+  },
+  detailsContent: {
+    padding: '16px',
+  },
+  detailsRow: {
+    marginBottom: '12px',
+  },
+  detailsLabel: {
+    fontSize: '11px',
+    color: dracula.comment,
+    textTransform: 'uppercase',
+    marginBottom: '4px',
+  },
+  detailsValue: {
+    fontSize: '13px',
+    color: dracula.foreground,
+    fontFamily: 'ui-monospace, monospace',
+    wordBreak: 'break-word',
+  },
+  detailsCode: {
+    fontFamily: 'ui-monospace, monospace',
+    fontSize: '11px',
+    background: dracula.currentLine,
+    padding: '8px',
+    borderRadius: '4px',
+    whiteSpace: 'pre-wrap',
+    wordBreak: 'break-all',
+    border: `1px solid ${dracula.border}`,
+  },
+};
+
+// Tab colors for each registry type
+const tabColors: Record<string, { bg: string; text: string; border: string }> = {
+  keys: { bg: '#e8f4fd', text: '#0066cc', border: '#0066cc' },
+  params: { bg: '#fff3e6', text: '#cc6600', border: '#cc6600' },
+  features: { bg: '#e8f8e8', text: '#228b22', border: '#228b22' },
+  capabilities: { bg: '#f3e8fd', text: '#7b2cbf', border: '#7b2cbf' },
+  tasks: { bg: '#ffe8ec', text: '#cc0033', border: '#cc0033' },
+  endpoints: { bg: '#e8f0f0', text: '#008080', border: '#008080' },
+};
+
+function getStatusStyle(status: string): React.CSSProperties {
+  switch (status) {
+    case 'active':
+    case 'implemented':
+      return { background: dracula.statusActive, color: dracula.statusActiveText };
+    case 'deprecated':
+      return { background: dracula.statusDeprecated, color: dracula.statusDeprecatedText };
+    case 'draft':
+      return { background: dracula.statusDraft, color: dracula.statusDraftText };
+    case 'blocked':
+      return { background: dracula.statusBlocked, color: dracula.statusBlockedText };
+    default:
+      return { background: dracula.comment, color: '#ffffff' };
+  }
+}
+
+function StatusBadge({ status }: { status: string }) {
+  return (
+    <span style={{ ...styles.statusBadge, ...getStatusStyle(status) }}>
+      {status}
+    </span>
+  );
+}
+
+// Draggable details panel component
+interface DraggablePanelProps {
+  panel: OpenPanel;
+  title: string;
+  children: React.ReactNode;
+  onClose: () => void;
+  onDragStart: () => void;
+  onDrag: (dx: number, dy: number) => void;
+  onDragEnd: () => void;
+}
+
+function DraggableDetailsPanel({ panel, title, children, onClose, onDragStart, onDrag, onDragEnd }: DraggablePanelProps) {
+  const [isDragging, setIsDragging] = useState(false);
+  const dragStartRef = useRef<{ x: number; y: number } | null>(null);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    // Only start drag from the header, not the close button
+    if ((e.target as HTMLElement).closest('button')) return;
+
+    e.preventDefault();
+    setIsDragging(true);
+    dragStartRef.current = { x: e.clientX, y: e.clientY };
+    onDragStart();
+
+    const handleMouseMove = (moveEvent: MouseEvent) => {
+      if (dragStartRef.current) {
+        const dx = moveEvent.clientX - dragStartRef.current.x;
+        const dy = moveEvent.clientY - dragStartRef.current.y;
+        dragStartRef.current = { x: moveEvent.clientX, y: moveEvent.clientY };
+        onDrag(dx, dy);
+      }
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+      dragStartRef.current = null;
+      onDragEnd();
+      document.removeEventListener('mousemove', handleMouseMove);
+      document.removeEventListener('mouseup', handleMouseUp);
+    };
+
+    document.addEventListener('mousemove', handleMouseMove);
+    document.addEventListener('mouseup', handleMouseUp);
+  }, [onDragStart, onDrag, onDragEnd]);
+
+  return (
+    <div
+      style={{
+        ...styles.detailsPanel,
+        left: panel.x,
+        top: panel.y,
+        zIndex: panel.zIndex,
+      }}
+    >
+      <div
+        style={{
+          ...styles.detailsHeader,
+          ...(isDragging ? styles.detailsHeaderDragging : {}),
+        }}
+        onMouseDown={handleMouseDown}
+      >
+        <span style={styles.detailsTitle}>{title}</span>
+        <button
+          style={styles.closeButton}
+          onClick={onClose}
+          onMouseEnter={(e) => e.currentTarget.style.color = dracula.foreground}
+          onMouseLeave={(e) => e.currentTarget.style.color = dracula.comment}
+        >
+          ×
+        </button>
+      </div>
+      <div style={styles.detailsContent}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+export default function RegistryViewer() {
+  const registries = useStore((s) => s.registries);
+  const loading = useStore((s) => s.registriesLoading);
+  const error = useStore((s) => s.registriesError);
+  const selectedTab = useStore((s) => s.selectedRegistryTab);
+  const searchQuery = useStore((s) => s.registrySearchQuery);
+  const selectedRegistryEntry = useStore((s) => s.selectedRegistryEntry);
+  const selectedEndpointEnv = useStore((s) => s.selectedEndpointEnv);
+  const loadRegistries = useStore((s) => s.loadRegistries);
+  const setRegistryTab = useStore((s) => s.setRegistryTab);
+  const setRegistrySearchQuery = useStore((s) => s.setRegistrySearchQuery);
+  const setSelectedRegistryEntry = useStore((s) => s.setSelectedRegistryEntry);
+  const setSelectedEndpointEnv = useStore((s) => s.setSelectedEndpointEnv);
+
+  // Local state for multiple open panels
+  const [openPanels, setOpenPanels] = useState<OpenPanel[]>([]);
+  const [nextZIndex, setNextZIndex] = useState(100);
+
+  useEffect(() => {
+    if (!registries && !loading && !error) {
+      loadRegistries();
+    }
+  }, [registries, loading, error, loadRegistries]);
+
+  // Auto-open panel when selectedRegistryEntry is set from URL
+  useEffect(() => {
+    if (selectedRegistryEntry !== null && registries) {
+      // Check if panel is already open
+      const alreadyOpen = openPanels.some(
+        p => p.id === selectedRegistryEntry && p.tab === selectedTab
+      );
+      if (!alreadyOpen) {
+        const offset = (openPanels.length % 5) * 30;
+        const newPanel: OpenPanel = {
+          id: selectedRegistryEntry,
+          tab: selectedTab,
+          x: window.innerWidth - 360 - offset,
+          y: 80 + offset,
+          zIndex: nextZIndex,
+        };
+        setNextZIndex(z => z + 1);
+        setOpenPanels(prev => [...prev, newPanel]);
+      }
+    }
+  }, [selectedRegistryEntry, selectedTab, registries]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const tabs: { id: RegistryTab; label: string; count: number }[] = useMemo(() => [
+    { id: 'keys', label: 'Keys', count: registries?.keys.length ?? 0 },
+    { id: 'params', label: 'Params', count: registries?.params.length ?? 0 },
+    { id: 'features', label: 'Features', count: registries?.features.length ?? 0 },
+    { id: 'capabilities', label: 'Capabilities', count: registries?.capabilities.length ?? 0 },
+    { id: 'tasks', label: 'Tasks', count: registries?.tasks.length ?? 0 },
+    { id: 'endpoints', label: 'Endpoints', count: registries?.endpoints[selectedEndpointEnv].length ?? 0 },
+  ], [registries, selectedEndpointEnv]);
+
+  const filteredData = useMemo(() => {
+    if (!registries) return [];
+    const query = searchQuery.toLowerCase();
+
+    const filterFn = <T extends { name: string; doc?: string }>(items: T[]): T[] => {
+      if (!query) return items;
+      return items.filter(item =>
+        item.name.toLowerCase().includes(query) ||
+        (item.doc && item.doc.toLowerCase().includes(query))
+      );
+    };
+
+    switch (selectedTab) {
+      case 'keys':
+        return filterFn(registries.keys);
+      case 'params':
+        return filterFn(registries.params);
+      case 'features':
+        return filterFn(registries.features);
+      case 'capabilities':
+        return registries.capabilities.filter(c =>
+          !query || c.name.toLowerCase().includes(query) || c.id.toLowerCase().includes(query) || c.doc.toLowerCase().includes(query)
+        );
+      case 'tasks':
+        return registries.tasks.filter(t =>
+          !query || t.op.toLowerCase().includes(query) || t.output_pattern.toLowerCase().includes(query)
+        );
+      case 'endpoints':
+        return registries.endpoints[selectedEndpointEnv].filter(e =>
+          !query || e.name.toLowerCase().includes(query) || e.endpoint_id.toLowerCase().includes(query) || e.kind.toLowerCase().includes(query)
+        );
+      default:
+        return [];
+    }
+  }, [registries, selectedTab, searchQuery, selectedEndpointEnv]);
+
+  // Open a new panel or bring existing to front
+  const handleRowClick = useCallback((id: string | number) => {
+    // Update URL with selected entry
+    setSelectedRegistryEntry(id);
+
+    setOpenPanels(prev => {
+      // Check if panel is already open
+      const existing = prev.find(p => p.id === id && p.tab === selectedTab);
+      if (existing) {
+        // Bring to front
+        setNextZIndex(z => z + 1);
+        return prev.map(p =>
+          p.id === id && p.tab === selectedTab
+            ? { ...p, zIndex: nextZIndex }
+            : p
+        );
+      }
+
+      // Open new panel with offset based on number of open panels
+      const offset = (prev.length % 5) * 30;
+      const newPanel: OpenPanel = {
+        id,
+        tab: selectedTab,
+        x: window.innerWidth - 360 - offset,
+        y: 80 + offset,
+        zIndex: nextZIndex,
+      };
+      setNextZIndex(z => z + 1);
+      return [...prev, newPanel];
+    });
+  }, [selectedTab, nextZIndex, setSelectedRegistryEntry]);
+
+  // Close a panel
+  const handleClosePanel = useCallback((id: string | number, tab: RegistryTab) => {
+    setOpenPanels(prev => prev.filter(p => !(p.id === id && p.tab === tab)));
+  }, []);
+
+  // Bring panel to front when starting drag
+  const handlePanelDragStart = useCallback((id: string | number, tab: RegistryTab) => {
+    setOpenPanels(prev => {
+      setNextZIndex(z => z + 1);
+      return prev.map(p =>
+        p.id === id && p.tab === tab
+          ? { ...p, zIndex: nextZIndex }
+          : p
+      );
+    });
+  }, [nextZIndex]);
+
+  // Update panel position during drag
+  const handlePanelDrag = useCallback((id: string | number, tab: RegistryTab, dx: number, dy: number) => {
+    setOpenPanels(prev =>
+      prev.map(p =>
+        p.id === id && p.tab === tab
+          ? { ...p, x: p.x + dx, y: p.y + dy }
+          : p
+      )
+    );
+  }, []);
+
+  // Get details for a panel
+  const getPanelDetails = useCallback((panel: OpenPanel) => {
+    if (!registries) return null;
+
+    switch (panel.tab) {
+      case 'keys':
+        return registries.keys.find(k => k.key_id === panel.id);
+      case 'params':
+        return registries.params.find(p => p.param_id === panel.id);
+      case 'features':
+        return registries.features.find(f => f.feature_id === panel.id);
+      case 'capabilities':
+        return registries.capabilities.find(c => c.id === panel.id);
+      case 'tasks':
+        return registries.tasks.find(t => t.op === panel.id);
+      case 'endpoints':
+        return registries.endpoints[selectedEndpointEnv].find(e => e.endpoint_id === panel.id);
+      default:
+        return null;
+    }
+  }, [registries, selectedEndpointEnv]);
+
+  // Get title for a panel
+  const getPanelTitle = useCallback((panel: OpenPanel) => {
+    const details = getPanelDetails(panel);
+    if (!details) return String(panel.id);
+
+    switch (panel.tab) {
+      case 'keys':
+        return (details as KeyEntry).name;
+      case 'params':
+        return (details as ParamEntry).name;
+      case 'features':
+        return (details as FeatureEntry).name;
+      case 'capabilities':
+        return (details as CapabilityEntry).name;
+      case 'tasks':
+        return (details as TaskEntry).op;
+      case 'endpoints':
+        return (details as EndpointEntry).name;
+      default:
+        return String(panel.id);
+    }
+  }, [getPanelDetails]);
+
+  // Check if an entry has an open panel
+  const isPanelOpen = useCallback((id: string | number) => {
+    return openPanels.some(p => p.id === id && p.tab === selectedTab);
+  }, [openPanels, selectedTab]);
+
+  if (loading) {
+    return (
+      <div style={styles.container}>
+        <div style={styles.loading}>Loading registries...</div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div style={styles.container}>
+        <div style={{ padding: '24px' }}>
+          <div style={styles.error}>{error}</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div style={styles.container}>
+      <div style={styles.header}>
+        <div style={styles.searchRow}>
+          <input
+            type="text"
+            placeholder="Search by name or description..."
+            value={searchQuery}
+            onChange={(e) => setRegistrySearchQuery(e.target.value)}
+            style={styles.searchInput}
+            onFocus={(e) => e.currentTarget.style.borderColor = dracula.purple}
+            onBlur={(e) => e.currentTarget.style.borderColor = dracula.border}
+          />
+        </div>
+        <div style={styles.tabBar}>
+          {tabs.map(tab => {
+            const colors = tabColors[tab.id];
+            const isActive = selectedTab === tab.id;
+            return (
+              <button
+                key={tab.id}
+                style={{
+                  ...styles.tab,
+                  ...(isActive ? {
+                    background: colors.bg,
+                    color: colors.text,
+                    borderColor: colors.border,
+                  } : {}),
+                }}
+                onClick={() => setRegistryTab(tab.id)}
+                onMouseEnter={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.background = colors.bg;
+                    e.currentTarget.style.color = colors.text;
+                    e.currentTarget.style.borderColor = colors.border;
+                  }
+                }}
+                onMouseLeave={(e) => {
+                  if (!isActive) {
+                    e.currentTarget.style.background = dracula.currentLine;
+                    e.currentTarget.style.color = dracula.comment;
+                    e.currentTarget.style.borderColor = 'transparent';
+                  }
+                }}
+              >
+                {tab.label}
+                <span style={styles.tabCount}>({tab.count})</span>
+              </button>
+            );
+          })}
+        </div>
+        {selectedTab === 'endpoints' && (
+          <div style={styles.envSelector}>
+            <span style={styles.envLabel}>Environment:</span>
+            <div style={styles.envButtons}>
+              {(['dev', 'test', 'prod'] as EndpointEnv[]).map(env => {
+                const isActive = selectedEndpointEnv === env;
+                const envColors: Record<EndpointEnv, { bg: string; text: string; border: string }> = {
+                  dev: { bg: '#e8f4fd', text: '#0066cc', border: '#0066cc' },
+                  test: { bg: '#fff3e6', text: '#cc6600', border: '#cc6600' },
+                  prod: { bg: '#ffe8ec', text: '#cc0033', border: '#cc0033' },
+                };
+                const colors = envColors[env];
+                return (
+                  <button
+                    key={env}
+                    style={{
+                      ...styles.envButton,
+                      ...(isActive ? {
+                        background: colors.bg,
+                        color: colors.text,
+                        borderColor: colors.border,
+                      } : {}),
+                    }}
+                    onClick={() => setSelectedEndpointEnv(env)}
+                    onMouseEnter={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.background = colors.bg;
+                        e.currentTarget.style.color = colors.text;
+                        e.currentTarget.style.borderColor = colors.border;
+                      }
+                    }}
+                    onMouseLeave={(e) => {
+                      if (!isActive) {
+                        e.currentTarget.style.background = dracula.currentLine;
+                        e.currentTarget.style.color = dracula.comment;
+                        e.currentTarget.style.borderColor = dracula.border;
+                      }
+                    }}
+                  >
+                    {env.toUpperCase()}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div style={styles.content}>
+        {filteredData.length === 0 ? (
+          <div style={styles.emptyState}>
+            {searchQuery ? 'No results found' : 'No entries'}
+          </div>
+        ) : (
+          <table style={styles.table}>
+            <thead>
+              {selectedTab === 'keys' && (
+                <tr>
+                  <th style={styles.th}>ID</th>
+                  <th style={styles.th}>Name</th>
+                  <th style={styles.th}>Type</th>
+                  <th style={styles.th}>Nullable</th>
+                  <th style={styles.th}>Status</th>
+                  <th style={styles.th}>Description</th>
+                </tr>
+              )}
+              {selectedTab === 'params' && (
+                <tr>
+                  <th style={styles.th}>ID</th>
+                  <th style={styles.th}>Name</th>
+                  <th style={styles.th}>Type</th>
+                  <th style={styles.th}>Nullable</th>
+                  <th style={styles.th}>Status</th>
+                  <th style={styles.th}>Description</th>
+                </tr>
+              )}
+              {selectedTab === 'features' && (
+                <tr>
+                  <th style={styles.th}>ID</th>
+                  <th style={styles.th}>Stage</th>
+                  <th style={styles.th}>Name</th>
+                  <th style={styles.th}>Type</th>
+                  <th style={styles.th}>Status</th>
+                  <th style={styles.th}>Description</th>
+                </tr>
+              )}
+              {selectedTab === 'capabilities' && (
+                <tr>
+                  <th style={styles.th}>ID</th>
+                  <th style={styles.th}>RFC</th>
+                  <th style={styles.th}>Name</th>
+                  <th style={styles.th}>Status</th>
+                  <th style={styles.th}>Description</th>
+                </tr>
+              )}
+              {selectedTab === 'tasks' && (
+                <tr>
+                  <th style={styles.th}>Op</th>
+                  <th style={styles.th}>Output Pattern</th>
+                  <th style={styles.th}>Params</th>
+                  <th style={styles.th}>Has writes_effect</th>
+                </tr>
+              )}
+              {selectedTab === 'endpoints' && (
+                <tr>
+                  <th style={styles.th}>ID</th>
+                  <th style={styles.th}>Name</th>
+                  <th style={styles.th}>Kind</th>
+                  <th style={styles.th}>Host:Port</th>
+                  <th style={styles.th}>Timeouts</th>
+                </tr>
+              )}
+            </thead>
+            <tbody>
+              {selectedTab === 'keys' && (filteredData as KeyEntry[]).map(entry => (
+                <tr
+                  key={entry.key_id}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.key_id) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.key_id)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.key_id)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.key_id)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.idCell }}>{entry.key_id}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.name}</td>
+                  <td style={{ ...styles.td, ...styles.typeCell }}>{entry.type}</td>
+                  <td style={{ ...styles.td, ...styles.boolCell }}>{entry.nullable ? 'true' : 'false'}</td>
+                  <td style={styles.td}><StatusBadge status={entry.status} /></td>
+                  <td style={{ ...styles.td, ...styles.docCell }}>{entry.doc}</td>
+                </tr>
+              ))}
+              {selectedTab === 'params' && (filteredData as ParamEntry[]).map(entry => (
+                <tr
+                  key={entry.param_id}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.param_id) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.param_id)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.param_id)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.param_id)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.idCell }}>{entry.param_id}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.name}</td>
+                  <td style={{ ...styles.td, ...styles.typeCell }}>{entry.type}</td>
+                  <td style={{ ...styles.td, ...styles.boolCell }}>{entry.nullable ? 'true' : 'false'}</td>
+                  <td style={styles.td}><StatusBadge status={entry.status} /></td>
+                  <td style={{ ...styles.td, ...styles.docCell }}>{entry.doc}</td>
+                </tr>
+              ))}
+              {selectedTab === 'features' && (filteredData as FeatureEntry[]).map(entry => (
+                <tr
+                  key={entry.feature_id}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.feature_id) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.feature_id)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.feature_id)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.feature_id)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.idCell }}>{entry.feature_id}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.stage}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.name}</td>
+                  <td style={{ ...styles.td, ...styles.typeCell }}>{entry.type}</td>
+                  <td style={styles.td}><StatusBadge status={entry.status} /></td>
+                  <td style={{ ...styles.td, ...styles.docCell }}>{entry.doc}</td>
+                </tr>
+              ))}
+              {selectedTab === 'capabilities' && (filteredData as CapabilityEntry[]).map(entry => (
+                <tr
+                  key={entry.id}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.id) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.id)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.id)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.id)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.nameCell, fontSize: '11px' }}>{entry.id}</td>
+                  <td style={{ ...styles.td, ...styles.idCell }}>{entry.rfc}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.name}</td>
+                  <td style={styles.td}><StatusBadge status={entry.status} /></td>
+                  <td style={{ ...styles.td, ...styles.docCell }}>{entry.doc}</td>
+                </tr>
+              ))}
+              {selectedTab === 'tasks' && (filteredData as TaskEntry[]).map(entry => (
+                <tr
+                  key={entry.op}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.op) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.op)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.op)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.op)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.op}</td>
+                  <td style={{ ...styles.td, ...styles.typeCell }}>{entry.output_pattern}</td>
+                  <td style={{ ...styles.td, fontSize: '12px' }}>
+                    {entry.params.map(p => p.name).join(', ') || '-'}
+                  </td>
+                  <td style={{ ...styles.td, ...styles.boolCell }}>
+                    {entry.writes_effect ? 'yes' : 'no'}
+                  </td>
+                </tr>
+              ))}
+              {selectedTab === 'endpoints' && (filteredData as EndpointEntry[]).map(entry => (
+                <tr
+                  key={entry.endpoint_id}
+                  style={{
+                    ...styles.tr,
+                    ...(isPanelOpen(entry.endpoint_id) ? styles.trSelected : {}),
+                  }}
+                  onClick={() => handleRowClick(entry.endpoint_id)}
+                  onMouseEnter={(e) => {
+                    if (!isPanelOpen(entry.endpoint_id)) {
+                      e.currentTarget.style.background = dracula.hover;
+                    }
+                  }}
+                  onMouseLeave={(e) => {
+                    if (!isPanelOpen(entry.endpoint_id)) {
+                      e.currentTarget.style.background = 'transparent';
+                    }
+                  }}
+                >
+                  <td style={{ ...styles.td, ...styles.idCell }}>{entry.endpoint_id}</td>
+                  <td style={{ ...styles.td, ...styles.nameCell }}>{entry.name}</td>
+                  <td style={{ ...styles.td, ...styles.typeCell }}>{entry.kind}</td>
+                  <td style={{ ...styles.td, fontFamily: 'ui-monospace, monospace', fontSize: '12px' }}>
+                    {entry.resolver.host}:{entry.resolver.port}
+                  </td>
+                  <td style={{ ...styles.td, fontSize: '11px', color: dracula.comment }}>
+                    conn: {entry.policy.connect_timeout_ms}ms, req: {entry.policy.request_timeout_ms}ms
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
+
+      {/* Details Panels */}
+      {openPanels.map(panel => {
+        const details = getPanelDetails(panel);
+        if (!details) return null;
+
+        return (
+          <DraggableDetailsPanel
+            key={`${panel.tab}-${panel.id}`}
+            panel={panel}
+            title={getPanelTitle(panel)}
+            onClose={() => handleClosePanel(panel.id, panel.tab)}
+            onDragStart={() => handlePanelDragStart(panel.id, panel.tab)}
+            onDrag={(dx, dy) => handlePanelDrag(panel.id, panel.tab, dx, dy)}
+            onDragEnd={() => {}}
+          >
+            {panel.tab === 'keys' && renderKeyDetails(details as KeyEntry)}
+            {panel.tab === 'params' && renderParamDetails(details as ParamEntry)}
+            {panel.tab === 'features' && renderFeatureDetails(details as FeatureEntry)}
+            {panel.tab === 'capabilities' && renderCapabilityDetails(details as CapabilityEntry)}
+            {panel.tab === 'tasks' && renderTaskDetails(details as TaskEntry)}
+            {panel.tab === 'endpoints' && renderEndpointDetails(details as EndpointEntry)}
+          </DraggableDetailsPanel>
+        );
+      })}
+    </div>
+  );
+}
+
+function renderKeyDetails(entry: KeyEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Key ID</div>
+        <div style={styles.detailsValue}>{entry.key_id}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Name</div>
+        <div style={styles.detailsValue}>{entry.name}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Type</div>
+        <div style={styles.detailsValue}>{entry.type}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Status</div>
+        <StatusBadge status={entry.status} />
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Nullable</div>
+        <div style={styles.detailsValue}>{entry.nullable ? 'true' : 'false'}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Allow Read</div>
+        <div style={styles.detailsValue}>{entry.allow_read ? 'true' : 'false'}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Allow Write</div>
+        <div style={styles.detailsValue}>{entry.allow_write ? 'true' : 'false'}</div>
+      </div>
+      {entry.default !== null && (
+        <div style={styles.detailsRow}>
+          <div style={styles.detailsLabel}>Default</div>
+          <div style={styles.detailsValue}>{JSON.stringify(entry.default)}</div>
+        </div>
+      )}
+      {entry.replaced_by !== null && (
+        <div style={styles.detailsRow}>
+          <div style={styles.detailsLabel}>Replaced By</div>
+          <div style={styles.detailsValue}>{entry.replaced_by}</div>
+        </div>
+      )}
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Description</div>
+        <div style={{ ...styles.detailsValue, fontFamily: 'inherit' }}>{entry.doc}</div>
+      </div>
+    </>
+  );
+}
+
+function renderParamDetails(entry: ParamEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Param ID</div>
+        <div style={styles.detailsValue}>{entry.param_id}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Name</div>
+        <div style={styles.detailsValue}>{entry.name}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Type</div>
+        <div style={styles.detailsValue}>{entry.type}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Status</div>
+        <StatusBadge status={entry.status} />
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Nullable</div>
+        <div style={styles.detailsValue}>{entry.nullable ? 'true' : 'false'}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Allow Read</div>
+        <div style={styles.detailsValue}>{entry.allow_read ? 'true' : 'false'}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Allow Write</div>
+        <div style={styles.detailsValue}>{entry.allow_write ? 'true' : 'false'}</div>
+      </div>
+      {entry.replaced_by !== null && (
+        <div style={styles.detailsRow}>
+          <div style={styles.detailsLabel}>Replaced By</div>
+          <div style={styles.detailsValue}>{entry.replaced_by}</div>
+        </div>
+      )}
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Description</div>
+        <div style={{ ...styles.detailsValue, fontFamily: 'inherit' }}>{entry.doc}</div>
+      </div>
+    </>
+  );
+}
+
+function renderFeatureDetails(entry: FeatureEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Feature ID</div>
+        <div style={styles.detailsValue}>{entry.feature_id}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Stage</div>
+        <div style={styles.detailsValue}>{entry.stage}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Name</div>
+        <div style={styles.detailsValue}>{entry.name}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Type</div>
+        <div style={styles.detailsValue}>{entry.type}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Status</div>
+        <StatusBadge status={entry.status} />
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Nullable</div>
+        <div style={styles.detailsValue}>{entry.nullable ? 'true' : 'false'}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Description</div>
+        <div style={{ ...styles.detailsValue, fontFamily: 'inherit' }}>{entry.doc}</div>
+      </div>
+    </>
+  );
+}
+
+function renderCapabilityDetails(entry: CapabilityEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Capability ID</div>
+        <div style={{ ...styles.detailsValue, fontSize: '11px', wordBreak: 'break-all' }}>{entry.id}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>RFC</div>
+        <div style={styles.detailsValue}>{entry.rfc}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Name</div>
+        <div style={styles.detailsValue}>{entry.name}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Status</div>
+        <StatusBadge status={entry.status} />
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Description</div>
+        <div style={{ ...styles.detailsValue, fontFamily: 'inherit' }}>{entry.doc}</div>
+      </div>
+      {entry.payload_schema && (
+        <div style={styles.detailsRow}>
+          <div style={styles.detailsLabel}>Payload Schema</div>
+          <pre style={styles.detailsCode}>
+            {JSON.stringify(entry.payload_schema, null, 2)}
+          </pre>
+        </div>
+      )}
+    </>
+  );
+}
+
+function renderTaskDetails(entry: TaskEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Op</div>
+        <div style={styles.detailsValue}>{entry.op}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Output Pattern</div>
+        <div style={styles.detailsValue}>{entry.output_pattern}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Parameters</div>
+        {entry.params.length > 0 ? (
+          <div style={{ marginTop: '4px' }}>
+            {entry.params.map(p => (
+              <div key={p.name} style={{ marginBottom: '8px', padding: '8px', background: dracula.currentLine, borderRadius: '4px' }}>
+                <div style={{ fontFamily: 'ui-monospace, monospace', fontWeight: 500 }}>{p.name}</div>
+                <div style={{ fontSize: '11px', color: dracula.comment, marginTop: '2px' }}>
+                  type: <span style={{ color: dracula.cyan }}>{p.type}</span>
+                  {' | '}
+                  required: <span style={{ color: p.required ? dracula.orange : dracula.green }}>{p.required ? 'yes' : 'no'}</span>
+                  {' | '}
+                  nullable: <span style={{ color: p.nullable ? dracula.orange : dracula.green }}>{p.nullable ? 'yes' : 'no'}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div style={{ ...styles.detailsValue, color: dracula.comment }}>None</div>
+        )}
+      </div>
+      {entry.writes_effect && (
+        <div style={styles.detailsRow}>
+          <div style={styles.detailsLabel}>Writes Effect</div>
+          <pre style={styles.detailsCode}>
+            {JSON.stringify(entry.writes_effect, null, 2)}
+          </pre>
+        </div>
+      )}
+    </>
+  );
+}
+
+function renderEndpointDetails(entry: EndpointEntry) {
+  return (
+    <>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Endpoint ID</div>
+        <div style={styles.detailsValue}>{entry.endpoint_id}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Name</div>
+        <div style={styles.detailsValue}>{entry.name}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Kind</div>
+        <div style={styles.detailsValue}>{entry.kind}</div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Resolver</div>
+        <div style={{ marginTop: '4px', padding: '8px', background: dracula.currentLine, borderRadius: '4px' }}>
+          <div style={{ fontSize: '11px', color: dracula.comment }}>
+            type: <span style={{ color: dracula.cyan }}>{entry.resolver.type}</span>
+          </div>
+          <div style={{ fontFamily: 'ui-monospace, monospace', marginTop: '4px' }}>
+            {entry.resolver.host}:{entry.resolver.port}
+          </div>
+        </div>
+      </div>
+      <div style={styles.detailsRow}>
+        <div style={styles.detailsLabel}>Policy</div>
+        <div style={{ marginTop: '4px', padding: '8px', background: dracula.currentLine, borderRadius: '4px' }}>
+          <div style={{ fontSize: '12px', marginBottom: '4px' }}>
+            <span style={{ color: dracula.comment }}>max_inflight:</span>{' '}
+            <span style={{ color: dracula.purple }}>{entry.policy.max_inflight}</span>
+          </div>
+          <div style={{ fontSize: '12px', marginBottom: '4px' }}>
+            <span style={{ color: dracula.comment }}>connect_timeout:</span>{' '}
+            <span style={{ color: dracula.orange }}>{entry.policy.connect_timeout_ms}ms</span>
+          </div>
+          <div style={{ fontSize: '12px' }}>
+            <span style={{ color: dracula.comment }}>request_timeout:</span>{' '}
+            <span style={{ color: dracula.orange }}>{entry.policy.request_timeout_ms}ms</span>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}

--- a/tools/visualizer/src/components/Toolbar.tsx
+++ b/tools/visualizer/src/components/Toolbar.tsx
@@ -1,6 +1,10 @@
 import { useStore } from '../state/store';
 import { dracula } from '../theme';
 
+interface ToolbarProps {
+  onEdit?: () => void;
+}
+
 const styles: Record<string, React.CSSProperties> = {
   dock: {
     position: 'absolute',
@@ -38,9 +42,10 @@ const styles: Record<string, React.CSSProperties> = {
   },
 };
 
-export default function Toolbar() {
+export default function Toolbar({ onEdit }: ToolbarProps) {
   const graph = useStore((s) => s.graph);
   const planJson = useStore((s) => s.planJson);
+  const sourceCode = useStore((s) => s.sourceCode);
   const fitToView = useStore((s) => s.fitToView);
 
   if (!planJson) return null;
@@ -49,9 +54,12 @@ export default function Toolbar() {
   const edgeCount = graph?.edges.length ?? 0;
 
   const handleFit = () => {
+    // Get the canvas container (parent of canvas element), not the canvas itself
+    // PixiJS canvas has different dimensions due to resolution/autoDensity
     const canvas = document.querySelector('canvas');
-    if (canvas) {
-      fitToView(canvas.clientWidth, canvas.clientHeight);
+    const container = canvas?.parentElement;
+    if (container) {
+      fitToView(container.clientWidth, container.clientHeight);
     }
   };
 
@@ -68,6 +76,16 @@ export default function Toolbar() {
       >
         Fit
       </button>
+      {sourceCode && onEdit && (
+        <button
+          style={{ ...styles.button, background: dracula.green, color: dracula.background }}
+          onClick={onEdit}
+          onMouseOver={(e) => (e.currentTarget.style.opacity = '0.8')}
+          onMouseOut={(e) => (e.currentTarget.style.opacity = '1')}
+        >
+          Edit
+        </button>
+      )}
     </div>
   );
 }

--- a/tools/visualizer/src/theme.ts
+++ b/tools/visualizer/src/theme.ts
@@ -39,6 +39,18 @@ export const dracula = {
   selected: '#e8e8e8',
   buttonBg: '#f4f4f4',
   buttonHover: '#e0e0e0',
+
+  // Status badges
+  statusActive: '#00c986',
+  statusActiveText: '#ffffff',
+  statusImplemented: '#00c986',
+  statusImplementedText: '#ffffff',
+  statusDeprecated: '#ffb700',
+  statusDeprecatedText: '#000000',
+  statusDraft: '#0092ff',
+  statusDraftText: '#ffffff',
+  statusBlocked: '#ff0037',
+  statusBlockedText: '#ffffff',
 };
 
 // PixiJS uses hex numbers

--- a/tools/visualizer/src/types.ts
+++ b/tools/visualizer/src/types.ts
@@ -100,3 +100,92 @@ export interface VisGraph {
   nodes: Map<string, VisNode>;
   edges: VisEdge[];
 }
+
+// Registry types (from artifacts/*.json)
+
+export interface KeyEntry {
+  key_id: number;
+  name: string;
+  type: string;
+  nullable: boolean;
+  doc: string;
+  status: 'active' | 'deprecated' | 'blocked';
+  allow_read: boolean;
+  allow_write: boolean;
+  replaced_by: number | null;
+  default: number | string | boolean | null;
+}
+
+export interface ParamEntry {
+  param_id: number;
+  name: string;
+  type: string;
+  nullable: boolean;
+  doc: string;
+  status: 'active' | 'deprecated' | 'blocked';
+  allow_read: boolean;
+  allow_write: boolean;
+  replaced_by: number | null;
+}
+
+export interface FeatureEntry {
+  feature_id: number;
+  stage: string;
+  name: string;
+  type: string;
+  nullable: boolean;
+  status: 'active' | 'deprecated' | 'blocked';
+  doc: string;
+}
+
+export interface CapabilityEntry {
+  id: string;
+  rfc: string;
+  name: string;
+  status: 'implemented' | 'draft' | 'deprecated' | 'blocked';
+  doc: string;
+  payload_schema: Record<string, unknown> | null;
+}
+
+export interface TaskParamEntry {
+  name: string;
+  type: string;
+  required: boolean;
+  nullable: boolean;
+}
+
+export interface TaskEntry {
+  op: string;
+  output_pattern: string;
+  params: TaskParamEntry[];
+  writes_effect?: unknown;
+}
+
+export interface EndpointEntry {
+  endpoint_id: string;
+  name: string;
+  kind: string;
+  resolver: {
+    type: string;
+    host: string;
+    port: number;
+  };
+  policy: {
+    max_inflight: number;
+    connect_timeout_ms: number;
+    request_timeout_ms: number;
+  };
+}
+
+export type EndpointEnv = 'dev' | 'test' | 'prod';
+
+export interface RegistryData {
+  keys: KeyEntry[];
+  params: ParamEntry[];
+  features: FeatureEntry[];
+  capabilities: CapabilityEntry[];
+  tasks: TaskEntry[];
+  endpoints: Record<EndpointEnv, EndpointEntry[]>;
+}
+
+export type RegistryTab = 'keys' | 'params' | 'features' | 'capabilities' | 'tasks' | 'endpoints';

--- a/tools/visualizer/src/vite-env.d.ts
+++ b/tools/visualizer/src/vite-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="vite/client" />
+
+declare const __PROJECT_ROOT__: string;
+declare const __PROJECT_NAME__: string;

--- a/tools/visualizer/vite.config.ts
+++ b/tools/visualizer/vite.config.ts
@@ -152,9 +152,17 @@ function compileApi() {
   };
 }
 
+// Get project root directory name for display
+const projectRoot = path.resolve(__dirname, '../..');
+const projectName = path.basename(projectRoot);
+
 export default defineConfig({
   plugins: [react(), serveLocalPublic(), servePlanSources(), compileApi()],
   publicDir: path.resolve(__dirname, '../../artifacts'),
+  define: {
+    __PROJECT_ROOT__: JSON.stringify(projectRoot),
+    __PROJECT_NAME__: JSON.stringify(projectName),
+  },
   server: {
     port: 5175,
     open: true,


### PR DESCRIPTION
## Summary

Visualizer Step 5 adds two major features: a Registry Viewer for browsing DSL registries and the ability to edit existing plans.

### Registry Viewer
- Browse **Keys**, **Params**, **Features**, **Capabilities**, **Tasks**, and **Endpoints** in a tabbed interface
- Search/filter across name and documentation fields
- Status badges with color coding (active=green, deprecated=yellow, blocked=red)
- Multiple draggable detail panels can be open simultaneously
- Clickable cross-references in DetailsPanel (`Key[3001]` → jumps to registry entry)
- URL persistence (`?view=registries&tab=keys&selected=3001`)
- Generate `artifacts/tasks.json` from codegen for Tasks tab
- **Endpoints tab** with environment selector (DEV/TEST/PROD) - shows host:port and policy timeouts

### Edit Existing Plan
- **"Edit" button on plan cards** in home page selector - click to open source in editor
- **"Edit" button in canvas toolbar** when viewing a plan with source available
- Loads plan's `.plan.ts` source into Monaco editor for modification
- Edit button hidden in edit mode (already editing)

### Navbar Navigation
- **Editor / Plans / Registries** navigation tabs in header
- Active tab highlighted
- Replaces "Back to Plans" button for cleaner navigation

### Polish
- Project folder indicator in header showing which repo you're in
- Fixed Fit button using container dimensions instead of canvas (proper centering)
- Color-coded registry tabs (blue=keys, orange=params, green=features, etc.)

## Test plan
- [x] `pnpm run visualizer:build` passes
- [x] All 33 e2e tests pass (5 skipped as expected)
- [x] New `e2e/edit-plan.spec.ts` with 10 tests for edit flow and navbar
- [x] Manual testing of registry viewer, edit buttons, fit button

## Files changed
- `dsl/src/codegen.ts` - Generate tasks.json
- `artifacts/tasks.json` - New generated file
- `tools/visualizer/src/components/RegistryViewer.tsx` - New registry browser
- `tools/visualizer/src/App.tsx` - Navbar, edit handlers
- `tools/visualizer/src/state/store.ts` - Registry + edit state (incl. endpoint envs)
- `tools/visualizer/src/types.ts` - Registry type definitions (incl. EndpointEnv)
- `tools/visualizer/src/theme.ts` - Status badge colors
- Plus toolbar, editor, details panel, and test updates

🤖 Generated with [Claude Code](https://claude.ai/code)
