### PR TITLE
Step14 hardening: shutdown/drain contract + eventloop stop tests + async-timeout soak

### DIFF
--- a/docs/EVENT_LOOP_SHUTDOWN.md
+++ b/docs/EVENT_LOOP_SHUTDOWN.md
@@ -1,0 +1,201 @@
+# EventLoop Shutdown & Drain Contract
+
+This document defines the hard contract for EventLoop lifecycle management, shutdown ordering, and interaction with thread pools.
+
+## Lifecycle States
+
+```
+┌──────┐     Start()     ┌──────────┐     (thread ready)     ┌─────────┐
+│ Idle │ ───────────────►│ Starting │ ─────────────────────► │ Running │
+└──────┘                 └──────────┘                        └────┬────┘
+                               │                                  │
+                               │ Stop() during init               │ Stop()
+                               ▼                                  ▼
+                         ┌──────────┐                        ┌──────────┐
+                         │ Stopping │◄───────────────────────│ Stopping │
+                         └────┬─────┘                        └────┬─────┘
+                              │                                   │
+                              │ (cleanup complete)                │
+                              ▼                                   ▼
+                         ┌─────────┐                         ┌─────────┐
+                         │ Stopped │                         │ Stopped │
+                         └─────────┘                         └─────────┘
+```
+
+| State | Description |
+|-------|-------------|
+| **Idle** | Not started. `Post()` returns false. |
+| **Starting** | `Start()` called, thread spawning. `Post()` returns false. |
+| **Running** | Loop thread active. `Post()` accepts work. |
+| **Stopping** | Shutdown in progress. `Post()` returns false. |
+| **Stopped** | Loop thread exited. Destructor can run. |
+
+## Required Invariants (Must-Not-Break Rules)
+
+### Thread Ownership
+All libuv operations happen on the loop thread. Never call `uv_*` functions from other threads.
+
+### Post Contract
+
+```cpp
+bool Post(std::function<void()> fn);
+```
+
+| Condition | Behavior |
+|-----------|----------|
+| State == Running | Enqueue callback, return `true` |
+| State != Running | Return `false`, do NOT enqueue, do NOT execute |
+
+**Critical**: `Post()` must be safe to call from any thread at any time. After `Stop()` begins (state transitions to Stopping), `Post()` must return `false` and must never execute the callback.
+
+### Stop Contract
+
+```cpp
+void Stop();
+```
+
+- **Idempotent**: Multiple calls do not deadlock or crash
+- **Early state flip**: State transitions to `Stopping` atomically at the START of `Stop()`, before any other work
+- **Drains accepted work**: Callbacks already enqueued when Stop begins will execute
+- **Joins thread**: `Stop()` blocks until the loop thread exits (unless called from loop thread)
+
+### Stop-from-Loop-Thread
+
+If `Stop()` is called from within a callback (on the loop thread):
+- Executes shutdown inline
+- Detaches the thread to avoid self-join deadlock
+- Destructor will wait for thread exit via `exit_state_` condition variable
+
+**Warning**: Callbacks must not destroy the EventLoop. Destructor asserts if called from loop thread.
+
+## Drain Contract (Thread Pool Integration)
+
+### The Problem
+
+`OffloadCpuWithTimeout` and `OffloadCpu` submit work to `GetCPUThreadPool()`. When work completes, they call `loop.Post()` to resume the coroutine. If the EventLoop is destroyed while CPU work is in-flight, the completion callback will call `Post()` on a destroyed object.
+
+### The Solution
+
+**Before destroying EventLoop, drain all thread pools that can Post back:**
+
+```cpp
+// Shutdown sequence
+GetCPUThreadPool().wait_idle();  // Wait for all CPU work to complete
+loop.Stop();                      // Now safe to stop
+// EventLoop destructor runs
+```
+
+`ThreadPool::wait_idle()` blocks until `in_flight_ == 0`, ensuring no pending CPU jobs can call `Post()` after the loop is destroyed.
+
+### Late Completion (Async Timeout)
+
+When `AsyncWithTimeout` or `OffloadCpuWithTimeout` fires a timeout:
+1. The timeout wins (sets `done = true`)
+2. The coroutine resumes with timeout error
+3. The CPU/async work continues in the background
+4. When it completes, it checks `done` flag and finds it's a late completion
+5. Late completion calls `Post()` to clean up
+
+If `Post()` returns false (loop stopping), the cleanup is skipped safely because:
+- Shared state uses `shared_ptr` (prevents UAF)
+- Late completion checks `await_suspend_returned` flag before direct resume fallback
+
+## Recommended Shutdown Sequence
+
+For the engine/server/benchmark harness, follow this order:
+
+```
+1. Stop accepting new requests
+   └─► Set a "shutting down" flag at the application level
+
+2. Cancel/timeout in-flight requests
+   └─► Existing deadline/timeout mechanisms handle this
+
+3. Drain CPU thread pool
+   └─► GetCPUThreadPool().wait_idle()
+   └─► Ensures all OffloadCpu completions have Posted back
+
+4. Stop the EventLoop
+   └─► loop.Stop()
+   └─► State → Stopping (rejects new Posts)
+   └─► Drains remaining callbacks
+   └─► Closes handles, stops loop
+
+5. Join loop thread / destroy EventLoop
+   └─► Destructor waits for thread exit
+   └─► uv_loop_close() runs
+
+6. Destroy remaining resources
+   └─► AsyncIoClients, registries, etc.
+```
+
+### Example (from main.cpp benchmark mode)
+
+```cpp
+// Simplified shutdown
+try {
+    auto result = execute_plan_async_blocking(...);
+    // ... process result
+} catch (...) {
+    // Error handling
+}
+
+// Drain CPU pool before EventLoop destruction
+rankd::GetCPUThreadPool().wait_idle();
+
+// EventLoop destructor runs here (calls Stop if needed)
+```
+
+## Implementation Details
+
+### State Machine (Atomic CAS)
+
+All state transitions use `compare_exchange_strong` to eliminate race windows:
+
+```cpp
+// In Stop():
+State expected = State::Running;
+if (!state_.compare_exchange_strong(expected, State::Stopping)) {
+    // State changed - retry or handle other cases
+}
+```
+
+### Post() Double-Check Pattern
+
+```cpp
+bool Post(std::function<void()> fn) {
+    if (state_.load() != State::Running) {
+        return false;  // Fast path rejection
+    }
+    {
+        std::lock_guard<std::mutex> lock(queue_mutex_);
+        if (state_.load() != State::Running) {
+            return false;  // Re-check under lock
+        }
+        queue_.push(std::move(fn));
+    }
+    uv_async_send(&async_);
+    return true;
+}
+```
+
+The double-check prevents a race where `Stop()` drains the queue between the first check and the enqueue.
+
+## Testing
+
+Existing tests in `engine/tests/test_event_loop.cpp` verify:
+
+| Test | Invariant |
+|------|-----------|
+| "Post before Start returns false" | Post rejected in Idle state |
+| "Post after Stop returns false" | Post rejected in Stopped state |
+| "Post during Stop is rejected" | Post rejected during Stopping transition |
+| "Multiple Stop calls are idempotent" | Stop is safe to call repeatedly |
+| "Stop from within callback" | Stop-from-loop-thread works |
+| "Destruction without Stop" | Destructor calls Stop if needed |
+
+## Related Documentation
+
+- [event_loop_architecture.md](event_loop_architecture.md) - Overall EventLoop design
+- [THREADING_MODEL.md](THREADING_MODEL.md) - Thread pool architecture
+- [async_dag_scheduler_architecture.md](async_dag_scheduler_architecture.md) - Async scheduler and timeout handling

--- a/docs/REQUEST_LIFECYCLE.md
+++ b/docs/REQUEST_LIFECYCLE.md
@@ -1,0 +1,287 @@
+# Request Lifecycle
+
+This document traces through the runtime execution of a complex DAG plan using the async scheduler.
+
+## Example Plan
+
+```typescript
+import { definePlan } from "@ranking-dsl/runtime";
+
+export default definePlan({
+  name: "complex_dag",
+  build: (ctx) => {
+    const v = ctx.viewer({ endpoint: EP.redis.redis_default });
+
+    // Left branch: follow → media → vm
+    const followBranch = v
+      .follow({ endpoint: EP.redis.redis_default })
+      .media({ endpoint: EP.redis.redis_default })
+      .vm({ outKey: Key.score, expr: Key.id * coalesce(P.weight, 0.1) });
+
+    // Right branch: recommendation → media → vm
+    const recsBranch = v
+      .recommendation({ endpoint: EP.redis.redis_default })
+      .media({ endpoint: EP.redis.redis_default })
+      .vm({ outKey: Key.score, expr: Key.id * coalesce(P.weight, 0.1) });
+
+    // Merge, sort, take
+    return followBranch
+      .concat({ rhs: recsBranch })
+      .sort({ key: Key.score, order: "desc" })
+      .take({ count: 50 });
+  },
+});
+```
+
+## 1. Plan Compilation (Build Time)
+
+```
+TypeScript → dslc compiler → JSON artifact
+```
+
+The plan compiles to a DAG with 10 nodes:
+
+```
+         n0 (viewer)
+           /     \
+      n1(follow)  n2(recs)
+          |          |
+      n3(media)   n4(media)
+          |          |
+      n5(vm)      n6(vm)
+           \      /
+          n7(concat)
+              |
+          n8(sort)
+              |
+          n9(take)
+```
+
+## 2. Request Arrives
+
+```bash
+echo '{"user_id": 123}' | engine/bin/rankd --async_scheduler --plan_name complex_dag
+```
+
+**main.cpp** parses request, loads plan, initializes:
+- `EventLoop` (single libuv thread)
+- `AsyncIoClients` (Redis connection pool)
+- `GetCPUThreadPool()` (8 threads for vm/sort/etc)
+
+## 3. Async Scheduler Initialization
+
+**`execute_plan_async_blocking()`** builds scheduler state:
+
+```cpp
+struct AsyncSchedulerState {
+  deps_remaining[10];    // [0,1,1,1,1,1,1,2,1,1] - n7 needs 2 inputs
+  results[10];           // Empty slots for RowSets
+  ready_queue;           // Initially [n0] - viewer has no deps
+  inflight_count = 0;
+  first_error = nullopt;
+};
+```
+
+## 4. Node Execution Loop
+
+### Wave 1: n0 (viewer)
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Loop Thread                                                 │
+├─────────────────────────────────────────────────────────────┤
+│  spawn_ready_nodes() → sees n0 ready                        │
+│  run_node_async(n0) starts as coroutine                     │
+│                                                              │
+│  n0 has run_async (Redis HGETALL user:123)                  │
+│  co_await AsyncRedisClient::HGetAll(...)                    │
+│  └─► Coroutine SUSPENDS, hiredis sends command              │
+│                                                              │
+│  Loop polls for IO...                                        │
+│                                                              │
+│  Redis reply arrives!                                        │
+│  └─► Coroutine RESUMES with {user_id:123, country:"US"}     │
+│                                                              │
+│  n0 completes → results[0] = RowSet(1 row)                  │
+│  deps_remaining[n1]-- → 0 (ready!)                          │
+│  deps_remaining[n2]-- → 0 (ready!)                          │
+│  ready_queue = [n1, n2]                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Wave 2: n1 (follow) + n2 (recs) - CONCURRENT
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Loop Thread                                                 │
+├─────────────────────────────────────────────────────────────┤
+│  spawn_ready_nodes() → spawns n1 AND n2                     │
+│                                                              │
+│  run_node_async(n1):                                         │
+│    co_await Redis LRANGE follow:123 → SUSPENDS              │
+│                                                              │
+│  run_node_async(n2):                                         │
+│    co_await Redis LRANGE recs:123 → SUSPENDS                │
+│                                                              │
+│  Both coroutines suspended, both Redis commands in-flight!  │
+│  Loop polls... (handles both replies as they arrive)        │
+│                                                              │
+│  n1 reply: [101,102,103,104] → results[1] = RowSet(4 rows) │
+│  n2 reply: [201,202,203,204] → results[2] = RowSet(4 rows) │
+│                                                              │
+│  deps_remaining[n3]-- → 0, deps_remaining[n4]-- → 0         │
+│  ready_queue = [n3, n4]                                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Wave 3: n3 (media) + n4 (media) - CONCURRENT
+
+Same pattern - both spawn, both do Redis LRANGE, both suspend, both complete.
+
+### Wave 4: n5 (vm) + n6 (vm) - CPU OFFLOAD
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Loop Thread                          CPU Pool               │
+├─────────────────────────────────────────────────────────────┤
+│  run_node_async(n5):                                         │
+│    vm has NO run_async → wrap with OffloadCpu               │
+│    co_await OffloadCpu([&]() {                              │
+│      // Runs on CPU thread ─────────► [T1] eval expr        │
+│      return registry.execute(...)    │      Key.id * 0.1    │
+│    }) ← SUSPENDS                     │                      │
+│                                       │                      │
+│  run_node_async(n6):                  │                      │
+│    co_await OffloadCpu([&]() { ─────► [T2] eval expr        │
+│      ...                              │      Key.id * 0.1    │
+│    }) ← SUSPENDS                      │                      │
+│                                       │                      │
+│  Loop polls...                        ▼                      │
+│                                  T1 done: Post(resume n5)   │
+│  ◄─────────────────────────────────────                     │
+│  n5 resumes, completes                                       │
+│                                  T2 done: Post(resume n6)   │
+│  ◄─────────────────────────────────────                     │
+│  n6 resumes, completes                                       │
+│                                                              │
+│  deps_remaining[n7]-- → 1                                   │
+│  deps_remaining[n7]-- → 0 (ready!)                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### Wave 5: n7 (concat) - CPU
+
+```cpp
+// concat merges left + right branch results
+// Input: results[5] (4 rows) + results[6] (4 rows via NodeRef)
+// Output: RowSet(8 rows)
+```
+
+### Wave 6: n8 (sort) - CPU
+
+```cpp
+// sort by Key.score DESC
+// Updates PermutationVector, no data copy
+// Output: RowSet(8 rows, sorted)
+```
+
+### Wave 7: n9 (take) - CPU
+
+```cpp
+// take({ count: 50 })
+// Only 8 rows exist, so all pass through
+// Updates SelectionVector, no data copy
+// Output: RowSet(8 rows)
+```
+
+## 5. Completion
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  All nodes complete:                                         │
+│    inflight_count → 0                                        │
+│    main_coro.resume() via Post()                            │
+│                                                              │
+│  execute_plan_async() returns ExecutionResult:              │
+│    results: [n9's RowSet]                                   │
+│    schema_deltas: [...]                                      │
+│    success: true                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 6. Response
+
+```json
+{
+  "request_id": "...",
+  "candidates": [
+    {"id": 203, "score": 20.3},
+    {"id": 204, "score": 20.4},
+    ...
+  ]
+}
+```
+
+## Timeline Visualization
+
+```
+Time →
+     0ms     10ms    20ms    30ms    40ms    50ms
+      │       │       │       │       │       │
+n0    ████░░░░│       │       │       │       │  Redis HGETALL
+      │       │       │       │       │       │
+n1    │       ████░░░░│       │       │       │  Redis LRANGE (concurrent)
+n2    │       ████░░░░│       │       │       │  Redis LRANGE (concurrent)
+      │       │       │       │       │       │
+n3    │       │       ████░░░░│       │       │  Redis LRANGE (concurrent)
+n4    │       │       ████░░░░│       │       │  Redis LRANGE (concurrent)
+      │       │       │       │       │       │
+n5    │       │       │       ██░░░░░░│       │  CPU vm (concurrent)
+n6    │       │       │       ██░░░░░░│       │  CPU vm (concurrent)
+      │       │       │       │       │       │
+n7    │       │       │       │       █░░░░░░│  CPU concat
+n8    │       │       │       │       █░░░░░░│  CPU sort
+n9    │       │       │       │       █░░░░░░│  CPU take
+
+████ = Async IO (Redis)
+██ = CPU work
+░░ = Waiting/suspended
+```
+
+## Key Points
+
+1. **Parallelism**: Independent branches (n1/n2, n3/n4, n5/n6) run concurrently
+2. **No blocking**: Redis calls suspend coroutines, loop handles other work
+3. **CPU offload**: vm/sort/take run on thread pool, post back when done
+4. **Zero-copy**: sort/take update vectors, don't copy data
+5. **Single loop thread**: All scheduler state mutations happen here (no locks)
+
+## With Timeout/Deadline
+
+If `--deadline_ms 30` is set:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  Time 0ms: Request starts, deadline = now + 30ms            │
+│                                                              │
+│  Time 25ms: n5 (vm) starts                                  │
+│    effective_deadline = min(request_deadline, node_timeout) │
+│    co_await OffloadCpuWithTimeout(deadline, [...])          │
+│                                                              │
+│  Time 30ms: Deadline reached!                               │
+│    Timer fires → sets done=true → resumes with timeout error│
+│    CPU work continues in background (late completion)       │
+│                                                              │
+│  Response: {"error": "Node execution timeout"}              │
+│                                                              │
+│  Time 35ms: CPU work finishes (late completion)             │
+│    Checks done flag → already true → discards result        │
+│    Increments late_counter, cleans up                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+## Related Documentation
+
+- [async_dag_scheduler_architecture.md](async_dag_scheduler_architecture.md) - Scheduler internals
+- [EVENT_LOOP_SHUTDOWN.md](EVENT_LOOP_SHUTDOWN.md) - Shutdown/drain semantics
+- [THREADING_MODEL.md](THREADING_MODEL.md) - Thread pool architecture

--- a/docs/THREADING_MODEL.md
+++ b/docs/THREADING_MODEL.md
@@ -156,7 +156,9 @@ This enables higher concurrency with fewer threads (1 thread can have 100+ Redis
 | Step | Status | Description |
 |------|--------|-------------|
 | 14.5c.1 | ✅ Done | EventLoop + Task<T> + SleepMs awaitable |
-| 14.5c.2 | 🔲 | Async Redis awaitable (hiredis async) |
-| 14.5c.3 | 🔲 | Coroutine DAG scheduler integration |
+| 14.5c.2 | ✅ Done | Async Redis awaitable (hiredis async) |
+| 14.5c.3 | ✅ Done | Coroutine DAG scheduler integration |
 
 See [event_loop_architecture.md](event_loop_architecture.md) for detailed architecture diagrams.
+
+See [EVENT_LOOP_SHUTDOWN.md](EVENT_LOOP_SHUTDOWN.md) for shutdown/drain semantics.

--- a/docs/event_loop_architecture.md
+++ b/docs/event_loop_architecture.md
@@ -144,3 +144,11 @@ The destructor includes a runtime assert to catch this during development:
 ```cpp
 assert(!on_loop_thread && "EventLoop destroyed from its own callback");
 ```
+
+## Shutdown & Drain Semantics
+
+See [EVENT_LOOP_SHUTDOWN.md](EVENT_LOOP_SHUTDOWN.md) for the detailed shutdown contract, including:
+- Lifecycle state machine (Idle → Starting → Running → Stopping → Stopped)
+- Post/Stop invariants
+- Thread pool drain ordering
+- Recommended shutdown sequence

--- a/engine/src/async_dag_scheduler.cpp
+++ b/engine/src/async_dag_scheduler.cpp
@@ -293,7 +293,10 @@ Task<void> run_node_async(AsyncSchedulerState& state, size_t node_idx) {
           async_ctx.params = params.get();
           async_ctx.expr_table = expr.get();
           async_ctx.pred_table = pred.get();
-          async_ctx.stats = nullptr;  // Skip stats - result may be discarded on timeout
+          // Note: stats intentionally null for async tasks. On timeout, the task continues
+          // as a late completion and we can't reliably attribute timing. Caller handles
+          // overall request timing. See also CPU path (sync_ctx.stats = nullptr).
+          async_ctx.stats = nullptr;
           async_ctx.resolved_node_refs = refs->empty() ? nullptr : refs.get();
           async_ctx.request = req.get();
           async_ctx.endpoints = ep ? ep.get() : nullptr;

--- a/scripts/soak_async_timeout.sh
+++ b/scripts/soak_async_timeout.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# Soak test for async timeout race conditions.
+# Repeatedly runs must-timeout and mostly-success scenarios to catch
+# hangs, leaks, UAF, or race regressions in AsyncWithTimeout/OffloadCpuWithTimeout.
+#
+# Usage:
+#   ./scripts/soak_async_timeout.sh
+#   RUNS=50 CONCURRENCY=100 ./scripts/soak_async_timeout.sh
+#   PLAN_NAME=my_custom_plan ./scripts/soak_async_timeout.sh
+#
+# This script is for local stress testing. NOT wired into CI.
+
+set -euo pipefail
+
+# Find timeout command (GNU coreutils)
+# On macOS, install via: brew install coreutils
+if command -v timeout &>/dev/null; then
+    TIMEOUT_CMD="timeout"
+elif command -v gtimeout &>/dev/null; then
+    TIMEOUT_CMD="gtimeout"
+else
+    TIMEOUT_CMD=""
+    echo "Warning: 'timeout' command not found. Runs will not be protected against hangs."
+    echo "On macOS, install via: brew install coreutils"
+    echo ""
+fi
+
+# Configuration via environment variables
+BIN="${BIN:-engine/bin/rankd}"
+RUNS="${RUNS:-20}"
+CONCURRENCY="${CONCURRENCY:-64}"
+DEADLINE_MS_TIMEOUT="${DEADLINE_MS_TIMEOUT:-5}"      # Tiny deadline to force timeouts
+DEADLINE_MS_SUCCESS="${DEADLINE_MS_SUCCESS:-5000}"   # Generous deadline for success
+NODE_TIMEOUT_MS_TIMEOUT="${NODE_TIMEOUT_MS_TIMEOUT:-3}"   # Tiny node timeout for must-timeout
+NODE_TIMEOUT_MS_SUCCESS="${NODE_TIMEOUT_MS_SUCCESS:-0}"   # No node timeout for success (0=disabled)
+PLAN_NAME="${PLAN_NAME:-}"
+TIMEOUT_PER_RUN="${TIMEOUT_PER_RUN:-30}"  # Seconds before considering a run hung
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+echo "=========================================="
+echo "Async Timeout Soak Test"
+echo "=========================================="
+echo "BIN:                $BIN"
+echo "RUNS:               $RUNS"
+echo "CONCURRENCY:        $CONCURRENCY"
+echo "DEADLINE_MS_TIMEOUT:    $DEADLINE_MS_TIMEOUT"
+echo "DEADLINE_MS_SUCCESS:    $DEADLINE_MS_SUCCESS"
+echo "NODE_TIMEOUT_MS_TIMEOUT:$NODE_TIMEOUT_MS_TIMEOUT"
+echo "NODE_TIMEOUT_MS_SUCCESS:$NODE_TIMEOUT_MS_SUCCESS"
+echo "TIMEOUT_PER_RUN:    ${TIMEOUT_PER_RUN}s"
+echo "=========================================="
+
+# Verify binary exists
+if [[ ! -x "$BIN" ]]; then
+    echo -e "${RED}Error: Binary not found or not executable: $BIN${NC}"
+    echo "Build the engine first: cmake --build engine/build --parallel"
+    exit 1
+fi
+
+# Determine plan name
+if [[ -z "$PLAN_NAME" ]]; then
+    # Check if parallel_sleep_plan exists
+    if [[ -f "artifacts/plans/parallel_sleep_plan.plan.json" ]]; then
+        PLAN_NAME="parallel_sleep_plan"
+    else
+        # Fallback: find first plan with "sleep" in name
+        PLAN_NAME=$("$BIN" --list-plans 2>/dev/null | grep -i sleep | head -1 | awk '{print $1}' || true)
+
+        if [[ -z "$PLAN_NAME" ]]; then
+            echo -e "${RED}Error: No suitable plan found.${NC}"
+            echo "Available plans:"
+            "$BIN" --list-plans 2>/dev/null || echo "(could not list plans)"
+            echo ""
+            echo "Set PLAN_NAME env var to specify a plan, or ensure parallel_sleep_plan exists."
+            exit 1
+        fi
+    fi
+fi
+
+echo "Using plan: $PLAN_NAME"
+echo ""
+
+# Counters
+timeout_pass=0
+timeout_fail=0
+success_pass=0
+success_fail=0
+
+# Run a single scenario
+# Args: $1=run_index, $2=scenario_name, $3=deadline_ms, $4=node_timeout_ms
+run_scenario() {
+    local run_idx=$1
+    local scenario=$2
+    local deadline_ms=$3
+    local node_timeout_ms=$4
+    local exit_code=0
+
+    # Run with timeout to catch hangs (if timeout command available)
+    local cmd_prefix=""
+    if [[ -n "$TIMEOUT_CMD" ]]; then
+        cmd_prefix="$TIMEOUT_CMD $TIMEOUT_PER_RUN"
+    fi
+
+    # Build args (only add node_timeout if non-zero)
+    local node_timeout_arg=""
+    if [[ "$node_timeout_ms" -gt 0 ]]; then
+        node_timeout_arg="--node_timeout_ms $node_timeout_ms"
+    fi
+
+    if $cmd_prefix "$BIN" \
+        --async_scheduler \
+        --plan_name "$PLAN_NAME" \
+        --deadline_ms "$deadline_ms" \
+        $node_timeout_arg \
+        --bench "$CONCURRENCY" \
+        >/dev/null 2>&1; then
+        exit_code=0
+    else
+        exit_code=$?
+    fi
+
+    # For must-timeout scenario, we expect errors (timeouts), so exit_code != 0 is OK
+    # For mostly-success scenario, we expect success, so exit_code == 0 is expected
+
+    if [[ "$scenario" == "must-timeout" ]]; then
+        # Any exit (0 or non-0) is fine as long as it doesn't hang
+        # Exit code 124 from timeout command means it hung
+        if [[ $exit_code -eq 124 ]]; then
+            echo -e "  [${run_idx}] ${scenario}: ${RED}HUNG (timeout ${TIMEOUT_PER_RUN}s)${NC}"
+            return 1
+        else
+            echo -e "  [${run_idx}] ${scenario}: ${GREEN}OK${NC} (exit=$exit_code)"
+            return 0
+        fi
+    else
+        # mostly-success: expect exit 0
+        if [[ $exit_code -eq 0 ]]; then
+            echo -e "  [${run_idx}] ${scenario}: ${GREEN}OK${NC}"
+            return 0
+        elif [[ $exit_code -eq 124 ]]; then
+            echo -e "  [${run_idx}] ${scenario}: ${RED}HUNG (timeout ${TIMEOUT_PER_RUN}s)${NC}"
+            return 1
+        else
+            echo -e "  [${run_idx}] ${scenario}: ${YELLOW}FAIL${NC} (exit=$exit_code)"
+            return 1
+        fi
+    fi
+}
+
+# Main loop
+echo "Running $RUNS iterations..."
+echo ""
+
+for ((i=1; i<=RUNS; i++)); do
+    echo "Run $i/$RUNS:"
+
+    # Must-timeout scenario (tiny deadline + tiny node timeout forces timeouts + late completions)
+    if run_scenario "$i" "must-timeout" "$DEADLINE_MS_TIMEOUT" "$NODE_TIMEOUT_MS_TIMEOUT"; then
+        ((timeout_pass++))
+    else
+        ((timeout_fail++))
+    fi
+
+    # Mostly-success scenario (generous deadline, no node timeout)
+    if run_scenario "$i" "mostly-success" "$DEADLINE_MS_SUCCESS" "$NODE_TIMEOUT_MS_SUCCESS"; then
+        ((success_pass++))
+    else
+        ((success_fail++))
+    fi
+
+    echo ""
+done
+
+# Summary
+echo "=========================================="
+echo "Summary"
+echo "=========================================="
+echo "must-timeout:   $timeout_pass passed, $timeout_fail failed"
+echo "mostly-success: $success_pass passed, $success_fail failed"
+echo ""
+
+total_fail=$((timeout_fail + success_fail))
+if [[ $total_fail -gt 0 ]]; then
+    echo -e "${RED}SOAK FAILED: $total_fail failures${NC}"
+    exit 1
+else
+    echo -e "${GREEN}SOAK PASSED: All $((RUNS * 2)) scenarios completed${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary
- Add explicit shutdown/drain semantics doc for EventLoop lifecycle (`docs/EVENT_LOOP_SHUTDOWN.md`)
- Add regression test references (existing tests already cover Stop ⇒ Post rejected)
- Add local soak script for high-concurrency must-timeout scenarios (`scripts/soak_async_timeout.sh`)

## What's in the doc
- Lifecycle state machine (Idle → Starting → Running → Stopping → Stopped)
- Post contract: returns bool, rejected after Stop begins
- Stop contract: idempotent, sets state early via CAS
- Drain contract: `GetCPUThreadPool().wait_idle()` before EventLoop destruction
- Recommended shutdown sequence

## Existing regression tests (84 assertions)
| Test | Invariant |
|------|-----------|
| "Post before Start returns false" | Post rejected in Idle state |
| "Post after Stop returns false" | Post rejected in Stopped state |
| "Post during Stop is rejected" | Post rejected during Stopping transition |
| "Multiple Stop calls are idempotent" | Stop is safe to call repeatedly |
| "Stop from within callback" | Stop-from-loop-thread works |

## How to run
```bash
# Unit tests
engine/bin/event_loop_tests

# Soak script (manual stress test)
./scripts/soak_async_timeout.sh
RUNS=50 CONCURRENCY=100 ./scripts/soak_async_timeout.sh
```

🤖 Generated with [Claude Code](https://claude.ai/code)
via [Happy](https://happy.engineering)
