### PR TITLE
Step 14.5c.future: EventLoop benchmarking

### DIFF
--- a/docs/EVENT_LOOP_BENCH.md
+++ b/docs/EVENT_LOOP_BENCH.md
@@ -1,0 +1,265 @@
+# EventLoop Benchmarking
+
+This document describes the EventLoop micro-benchmarking capabilities added to `rankd`.
+
+## Overview
+
+The `--bench_eventloop` flag enables offline benchmarking of the EventLoop infrastructure without requiring Redis, plans, or any external dependencies. This is useful for:
+
+- Measuring Post() throughput and queue efficiency
+- Profiling timer callback scheduling
+- Comparing coroutine-based IO vs traditional thread pool approaches
+- Tracking latency distributions and memory usage
+
+## CLI Flags
+
+| Flag | Type | Default | Description |
+|------|------|---------|-------------|
+| `--bench_eventloop` | bool | false | Enable EventLoop benchmark mode |
+| `--bench_eventloop_mode` | string | "all" | Benchmark mode: `posts`, `timers`, `sleep_vs_pool`, or `all` |
+| `--bench_n` | int | 0 (auto) | Number of operations (0 uses mode-specific defaults) |
+| `--bench_producers` | int | 1 | Number of producer threads for `posts` mode |
+| `--bench_sleep_ms` | int | 1 | Sleep/timer duration in ms (0 allowed for timers mode) |
+| `--bench_tasks` | int | 1000 | Number of concurrent tasks for timer/sleep modes |
+| `--bench_json` | bool | false | Output results as JSON |
+
+## Benchmark Modes
+
+### Mode A: `posts` - Post() Throughput
+
+Measures the throughput of `EventLoop::Post()` with configurable producer thread counts.
+
+**Purpose**: Benchmark queue + wakeup overhead with 1 or N producer threads.
+
+**Pattern**:
+- Single producer: tight loop of `Post()` calls from one thread
+- Multi-producer: N threads, each posting `n/N` callbacks
+
+**Default n**: 1,000,000 (same for all producer counts for fair comparison)
+
+**Output**: total_posts, producers, wall_ms, posts_per_sec, rss_start/end
+
+```bash
+# Single producer (default)
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode posts
+
+# 4 producer threads
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode posts --bench_producers 4
+
+# Custom iteration count
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode posts --bench_n 200000
+```
+
+### Mode B: `timers` - Timer Callback Throughput
+
+Measures timer scheduling and callback execution via raw `uv_timer_t`.
+
+**Purpose**: Benchmark timer creation, scheduling, and callback dispatch through the full libuv timer path.
+
+**Pattern**: Creates N raw `uv_timer_t` handles with the specified timeout, measuring latency from timer start to callback execution. Uses `--bench_sleep_ms` to set the timer delay (0 = immediate fire but still goes through full timer scheduling).
+
+**Note**: This mode uses raw libuv timers instead of `SleepMs()` because `SleepMs(0)` has an optimization where `await_ready()` returns true, bypassing actual timer scheduling. Raw timers ensure we measure real timer overhead.
+
+**Default n**: 10,000 timers, **Default timeout**: 0ms
+
+**Output**: total_timers, wall_ms, timers_per_sec, latency (p50/p90/p99/max/mean), rss
+
+```bash
+# Default settings (0ms timers)
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode timers
+
+# Custom task count
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode timers --bench_n 50000
+
+# Non-zero timer delay (measures actual sleep accuracy)
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode timers --bench_sleep_ms 5
+```
+
+### Mode C: `sleep_vs_pool` - IO-Bound Comparison
+
+Compares N concurrent sleeps between EventLoop coroutines and ThreadPool.
+
+**Purpose**: Demonstrate the advantage of coroutine-based IO over thread-pool blocking IO for IO-bound workloads.
+
+**Part C1 - EventLoop coroutines**:
+- N concurrent `SleepMs(X)` coroutines
+- All complete in ~X ms (plus overhead) regardless of N
+- Single thread handles all sleeps via libuv timers
+
+**Part C2 - ThreadPool sleep_for**:
+- N tasks submitted to thread pool, each calls `sleep_for(X)`
+- Wall time ~= ceil(N / threads) * X
+- Limited by thread count
+
+**Defaults**: tasks=1000, sleep_ms=1
+
+**Output**: Per-path wall_ms, latency stats, speedup_ratio (pool/coro)
+
+```bash
+# Default settings
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode sleep_vs_pool
+
+# Larger task count with longer sleep
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode sleep_vs_pool \
+  --bench_tasks 5000 --bench_sleep_ms 5
+```
+
+## Output Formats
+
+### Human-Readable (default)
+
+```
+=== Posts: 1 producer ===
+  Total posts:     1000000
+  Producers:       1
+  Wall time:       34.1 ms
+  Throughput:      29.3M posts/sec
+  RSS start/end:   12.4 / 14.1 MB
+
+=== Timers: 0ms ===
+  Total timers:    10000
+  Wall time:       1.9 ms
+  Throughput:      5.23M timers/sec
+  Latency p50/p90/p99: 1006/1119/1144 us
+  Latency max/mean:    1250/1024 us
+  RSS start/end:   14.1 / 16.2 MB
+
+=== EventLoop Benchmark: sleep_vs_pool ===
+  Tasks:           1000
+  Sleep:           1 ms
+
+  Coroutine path:
+    Wall time:     8.2 ms
+    Latency p50/p90/p99: 1050/1080/1120 us
+
+  ThreadPool path:
+    Wall time:     125.4 ms
+    Latency p50/p90/p99: 1850/2400/3200 us
+
+  Speedup (pool/coro): 15.3x
+  RSS start/end:   16.2 / 18.5 MB
+```
+
+### JSON (`--bench_json`)
+
+```json
+{
+  "posts": {
+    "total_posts": 1000000,
+    "producers": 1,
+    "wall_ms": 34.1,
+    "posts_per_sec": 29325513.2,
+    "rss_start_kb": 12697,
+    "rss_end_kb": 14438
+  },
+  "timers": {
+    "total_timers": 10000,
+    "timer_ms": 0,
+    "wall_ms": 1.9,
+    "timers_per_sec": 5230125.4,
+    "latency": {
+      "min_us": 980.1,
+      "max_us": 1250.0,
+      "mean_us": 1024.3,
+      "p50_us": 1006.0,
+      "p90_us": 1119.0,
+      "p99_us": 1144.0,
+      "count": 10000
+    },
+    "rss_start_kb": 14438,
+    "rss_end_kb": 16589
+  },
+  "sleep_vs_pool": {
+    "tasks": 1000,
+    "sleep_ms": 1,
+    "coro_wall_ms": 8.2,
+    "coro_latency": { ... },
+    "pool_wall_ms": 125.4,
+    "pool_latency": { ... },
+    "speedup_ratio": 15.3,
+    "rss_start_kb": 16589,
+    "rss_end_kb": 18944
+  }
+}
+```
+
+## Usage Examples
+
+```bash
+# Build
+cmake --build engine/build --parallel
+
+# Run all benchmarks (human output)
+engine/bin/rankd --bench_eventloop
+
+# Run all benchmarks (JSON output)
+engine/bin/rankd --bench_eventloop --bench_json
+
+# Test specific modes
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode posts --bench_n 50000
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode posts --bench_producers 4
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode timers --bench_n 5000
+engine/bin/rankd --bench_eventloop --bench_eventloop_mode sleep_vs_pool --bench_tasks 500 --bench_sleep_ms 5
+
+# Verify no Redis/plans required (offline)
+# All above commands work without Redis running or artifacts present
+```
+
+## Interpreting Results
+
+### posts Mode
+
+- **posts_per_sec**: Higher is better. Typical values: 1-5M/sec on modern hardware.
+- Scaling with producers shows lock contention in the queue.
+- RSS growth indicates per-callback memory overhead.
+
+### timers Mode
+
+- **timers_per_sec**: Higher is better. Measures libuv timer efficiency.
+- **Latency p99**: With 0ms timers, expect ~1ms (libuv timer granularity). With non-zero timers, latency should be close to the requested sleep time.
+- This mode uses raw `uv_timer_t` to measure real timer scheduling overhead. Note: `SleepMs(0)` has an optimization that bypasses timer scheduling (`await_ready` returns true), so we use raw timers here.
+
+### sleep_vs_pool Mode
+
+- **speedup_ratio**: Shows how much faster coroutines are for IO-bound work.
+- Expected: `pool_wall_ms ≈ ceil(tasks / threads) * sleep_ms`
+- Expected: `coro_wall_ms ≈ sleep_ms + small_overhead`
+- Coroutines win big when `tasks >> threads` (common in IO-heavy workloads).
+
+## Implementation Details
+
+### Files
+
+| File | Purpose |
+|------|---------|
+| `engine/include/bench_stats.h` | LatencyStats struct, compute_latency_stats(), RSS helpers |
+| `engine/include/bench_event_loop.h` | BenchEventLoopConfig, run_bench_eventloop() |
+| `engine/src/bench_event_loop.cpp` | All benchmark implementations |
+
+### Safe Coroutine Pattern
+
+The benchmarks use the standard safe coroutine pattern where `Task<void>` objects are stored in a vector and kept alive until completion:
+
+```cpp
+std::vector<Task<void>> tasks;
+for (int i = 0; i < n; ++i) {
+  tasks.push_back(make_coro(loop, ...));  // Factory function
+}
+for (auto& task : tasks) {
+  loop.Post([&task]() { task.start(); });
+}
+// Wait for completion...
+// Tasks go out of scope safely after completion
+```
+
+### RSS Measurement
+
+- macOS: Uses `mach_task_basic_info` for accurate current RSS
+- Linux: Falls back to `getrusage` peak RSS (no easy current RSS without /proc)
+- Both platforms report in KB for consistency
+
+## See Also
+
+- [docs/event_loop_architecture.md](event_loop_architecture.md) - EventLoop design
+- [docs/EVENT_LOOP_SHUTDOWN.md](EVENT_LOOP_SHUTDOWN.md) - Lifecycle and shutdown contract
+- [docs/THREADING_MODEL.md](THREADING_MODEL.md) - Thread pool architecture

--- a/docs/IMPLEMENTATION_PROGRESS.md
+++ b/docs/IMPLEMENTATION_PROGRESS.md
@@ -330,15 +330,29 @@ This document tracks the implementation status of all features in the dag-execut
 - **Tests**: Existing EventLoop tests cover shutdown cases (84 assertions in 28 test cases)
 - **Soak script**: `./scripts/soak_async_timeout.sh` runs must-timeout + mostly-success scenarios
 
+### Step 14.5c.future: EventLoop Benchmarking ✅
+- **Goal**: Add EventLoop micro-benchmarking for throughput and latency measurement
+- **Status**: Complete
+- **Files**:
+  - `engine/include/bench_stats.h` - LatencyStats, percentile computation, RSS helpers
+  - `engine/include/bench_event_loop.h` - BenchEventLoopConfig, run_bench_eventloop()
+  - `engine/src/bench_event_loop.cpp` - All benchmark implementations
+  - `docs/EVENT_LOOP_BENCH.md` - Usage documentation
+- **CLI Flags**:
+  - `--bench_eventloop`: Enable benchmark mode (early exit, no dependencies)
+  - `--bench_eventloop_mode`: posts|timers|sleep_vs_pool|all
+  - `--bench_n`, `--bench_producers`, `--bench_sleep_ms`, `--bench_tasks`: Mode-specific params
+  - `--bench_json`: JSON output format
+- **Benchmark Modes**:
+  - `posts`: Post() throughput with 1 or N producer threads
+  - `timers`: Timer callback throughput via SleepMs(0) coroutines
+  - `sleep_vs_pool`: Compare N concurrent sleeps (EventLoop coroutines vs ThreadPool)
+- **Output**: Latency distribution (p50/p90/p99/max/mean), throughput, RSS memory
+- **Usage**: `engine/bin/rankd --bench_eventloop --bench_json`
+
 ---
 
 ## 🔲 Not Yet Implemented
-
-### Step 14.5c.future: EventLoop Benchmarking
-- [ ] Benchmark EventLoop throughput (posts/sec, timers/sec)
-- [ ] Compare coroutine overhead vs thread pool for IO-bound workloads
-- [ ] Profile memory usage (coroutine frames vs thread stacks)
-- [ ] Measure latency distribution under load
 
 ### Step 14.2 Follow-up: Endpoint Registry Hardening
 - [ ] Validate endpoint digests: recompute from parsed entries, compare against JSON values, reject mismatched --env

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -95,6 +95,7 @@ add_executable(rankd
   src/event_loop.cpp
   src/async_redis_client.cpp
   src/async_io_clients.cpp
+  src/bench_event_loop.cpp
   ${TASK_SOURCES}
 )
 

--- a/engine/include/bench_event_loop.h
+++ b/engine/include/bench_event_loop.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <string>
+
+namespace ranking {
+
+// Configuration for EventLoop benchmarks
+struct BenchEventLoopConfig {
+  std::string mode = "all";      // posts|timers|sleep_vs_pool|all
+  int n = 0;                     // 0 = use mode default
+  int producers = 1;             // for posts mode
+  int sleep_ms = 1;              // for timer/sleep modes
+  int tasks = 1000;              // for timer/sleep modes
+  bool json_output = false;      // JSON vs human-readable output
+};
+
+// Run EventLoop benchmarks according to config.
+// Returns 0 on success, non-zero on error.
+int run_bench_eventloop(const BenchEventLoopConfig& config);
+
+}  // namespace ranking

--- a/engine/include/bench_stats.h
+++ b/engine/include/bench_stats.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+#ifdef __APPLE__
+#include <mach/mach.h>
+#endif
+
+#include <sys/resource.h>
+
+namespace ranking {
+
+// Latency statistics with percentiles
+struct LatencyStats {
+  double min_us = 0.0;
+  double max_us = 0.0;
+  double mean_us = 0.0;
+  double p50_us = 0.0;
+  double p90_us = 0.0;
+  double p99_us = 0.0;
+  size_t count = 0;
+};
+
+// Compute latency statistics from a vector of latencies in microseconds.
+// IMPORTANT: Modifies the input vector (sorts in place for efficiency).
+inline LatencyStats compute_latency_stats(std::vector<double>& latencies_us) {
+  LatencyStats stats;
+  if (latencies_us.empty()) {
+    return stats;
+  }
+
+  stats.count = latencies_us.size();
+
+  // Sort for percentile computation
+  std::sort(latencies_us.begin(), latencies_us.end());
+
+  stats.min_us = latencies_us.front();
+  stats.max_us = latencies_us.back();
+
+  double sum = std::accumulate(latencies_us.begin(), latencies_us.end(), 0.0);
+  stats.mean_us = sum / static_cast<double>(stats.count);
+
+  // Percentile indices (0-based)
+  auto percentile_idx = [&](double p) -> size_t {
+    size_t idx = static_cast<size_t>(p * static_cast<double>(stats.count));
+    if (idx >= stats.count) {
+      idx = stats.count - 1;
+    }
+    return idx;
+  };
+
+  stats.p50_us = latencies_us[percentile_idx(0.50)];
+  stats.p90_us = latencies_us[percentile_idx(0.90)];
+  stats.p99_us = latencies_us[percentile_idx(0.99)];
+
+  return stats;
+}
+
+// Get peak RSS in KB using getrusage.
+// Note: macOS returns bytes, Linux returns KB. We normalize to KB.
+inline int64_t get_peak_rss_kb() {
+  struct rusage usage;
+  if (getrusage(RUSAGE_SELF, &usage) != 0) {
+    return -1;
+  }
+#ifdef __APPLE__
+  // macOS: ru_maxrss is in bytes
+  return usage.ru_maxrss / 1024;
+#else
+  // Linux: ru_maxrss is in KB
+  return usage.ru_maxrss;
+#endif
+}
+
+// Get current RSS in KB.
+// macOS: Uses mach task_info for accurate current RSS.
+// Linux: Falls back to peak RSS (no easy way to get current without /proc).
+inline int64_t get_current_rss_kb() {
+#ifdef __APPLE__
+  struct mach_task_basic_info info;
+  mach_msg_type_number_t count = MACH_TASK_BASIC_INFO_COUNT;
+  if (task_info(mach_task_self(), MACH_TASK_BASIC_INFO,
+                reinterpret_cast<task_info_t>(&info), &count) != KERN_SUCCESS) {
+    return get_peak_rss_kb();  // Fallback
+  }
+  return static_cast<int64_t>(info.resident_size) / 1024;
+#else
+  // Linux: Use peak RSS as approximation (reading /proc is slower)
+  return get_peak_rss_kb();
+#endif
+}
+
+}  // namespace ranking

--- a/engine/src/bench_event_loop.cpp
+++ b/engine/src/bench_event_loop.cpp
@@ -1,0 +1,527 @@
+#include "bench_event_loop.h"
+
+#include <atomic>
+#include <chrono>
+#include <future>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "bench_stats.h"
+#include "coro_task.h"
+#include "event_loop.h"
+#include "thread_pool.h"
+#include "uv_sleep.h"
+
+using json = nlohmann::ordered_json;
+using namespace std::chrono;
+
+namespace ranking {
+
+// =============================================================================
+// Mode A: posts - Post() throughput
+// =============================================================================
+
+struct PostsBenchResult {
+  int total_posts = 0;
+  int producers = 0;
+  double wall_ms = 0.0;
+  double posts_per_sec = 0.0;
+  int64_t rss_start_kb = 0;
+  int64_t rss_end_kb = 0;
+};
+
+static PostsBenchResult bench_posts(int n, int producers) {
+  PostsBenchResult result;
+  result.total_posts = n;
+  result.producers = producers;
+  result.rss_start_kb = get_current_rss_kb();
+
+  EventLoop loop;
+  loop.Start();
+
+  std::atomic<int> counter{0};
+  std::promise<void> done;
+  auto done_future = done.get_future();
+  std::atomic<bool> signaled{false};
+
+  auto callback = [&]() {
+    int prev = counter.fetch_add(1);
+    if (prev == n - 1) {
+      bool expected = false;
+      if (signaled.compare_exchange_strong(expected, true)) {
+        done.set_value();
+      }
+    }
+  };
+
+  auto start = steady_clock::now();
+
+  if (producers == 1) {
+    // Single producer: tight loop
+    for (int i = 0; i < n; ++i) {
+      loop.Post(callback);
+    }
+  } else {
+    // Multi-producer: N threads, each posting n/producers callbacks
+    std::vector<std::thread> threads;
+    threads.reserve(producers);
+    int per_thread = n / producers;
+    int remainder = n % producers;
+
+    for (int t = 0; t < producers; ++t) {
+      int count = per_thread + (t < remainder ? 1 : 0);
+      threads.emplace_back([&loop, &callback, count]() {
+        for (int i = 0; i < count; ++i) {
+          loop.Post(callback);
+        }
+      });
+    }
+
+    for (auto& t : threads) {
+      t.join();
+    }
+  }
+
+  done_future.wait();
+  auto end = steady_clock::now();
+
+  loop.Stop();
+
+  result.wall_ms = duration<double, std::milli>(end - start).count();
+  result.posts_per_sec = static_cast<double>(n) / (result.wall_ms / 1000.0);
+  result.rss_end_kb = get_current_rss_kb();
+
+  return result;
+}
+
+// =============================================================================
+// Mode B: timers - Raw uv_timer_t throughput (actual timer scheduling)
+// =============================================================================
+
+struct TimersBenchResult {
+  int total_timers = 0;
+  int timeout_ms = 0;
+  double wall_ms = 0.0;
+  double timers_per_sec = 0.0;
+  LatencyStats latency;
+  int64_t rss_start_kb = 0;
+  int64_t rss_end_kb = 0;
+};
+
+// State for raw timer benchmark - uses actual uv_timer_t scheduling
+struct TimerBenchState {
+  std::vector<double>* latencies;
+  std::mutex* latencies_mutex;
+  std::atomic<int>* completed;
+  std::promise<void>* done;
+  int total;
+  steady_clock::time_point start_time;
+};
+
+static void OnTimerBenchCallback(uv_timer_t* t) {
+  auto end = steady_clock::now();
+  auto* state = static_cast<TimerBenchState*>(t->data);
+
+  double latency_us = duration<double, std::micro>(end - state->start_time).count();
+  {
+    std::lock_guard<std::mutex> lock(*state->latencies_mutex);
+    state->latencies->push_back(latency_us);
+  }
+
+  int prev = state->completed->fetch_add(1);
+  if (prev == state->total - 1) {
+    state->done->set_value();
+  }
+
+  // Clean up timer
+  uv_timer_stop(t);
+  uv_close(reinterpret_cast<uv_handle_t*>(t), [](uv_handle_t* h) {
+    auto* timer = reinterpret_cast<uv_timer_t*>(h);
+    delete static_cast<TimerBenchState*>(timer->data);
+    delete timer;
+  });
+}
+
+static TimersBenchResult bench_timers(int n, int timeout_ms) {
+  TimersBenchResult result;
+  result.total_timers = n;
+  result.timeout_ms = timeout_ms;
+  result.rss_start_kb = get_current_rss_kb();
+
+  EventLoop loop;
+  loop.Start();
+
+  std::vector<double> latencies;
+  latencies.reserve(n);
+  std::mutex latencies_mutex;
+  std::atomic<int> completed{0};
+  std::promise<void> done;
+  auto done_future = done.get_future();
+
+  auto start = steady_clock::now();
+
+  // Schedule all timers via Post to loop thread
+  for (int i = 0; i < n; ++i) {
+    bool posted = loop.Post([&loop, &latencies, &latencies_mutex, &completed, &done, n, timeout_ms]() {
+      auto* timer = new uv_timer_t;
+      auto* state = new TimerBenchState{
+          &latencies, &latencies_mutex, &completed, &done, n, steady_clock::now()};
+      timer->data = state;
+      uv_timer_init(loop.RawLoop(), timer);
+      uv_timer_start(timer, OnTimerBenchCallback, static_cast<uint64_t>(timeout_ms), 0);
+    });
+    if (!posted) {
+      std::cerr << "Error: loop.Post() failed in timers benchmark" << std::endl;
+      loop.Stop();
+      return result;
+    }
+  }
+
+  done_future.wait();
+  auto end = steady_clock::now();
+
+  loop.Stop();
+
+  result.wall_ms = duration<double, std::milli>(end - start).count();
+  result.timers_per_sec = static_cast<double>(n) / (result.wall_ms / 1000.0);
+  result.latency = compute_latency_stats(latencies);
+  result.rss_end_kb = get_current_rss_kb();
+
+  return result;
+}
+
+// =============================================================================
+// Mode C: sleep_vs_pool - IO-bound comparison
+// =============================================================================
+
+struct SleepVsPoolResult {
+  int tasks = 0;
+  int sleep_ms = 0;
+
+  // Coroutine path
+  double coro_wall_ms = 0.0;
+  LatencyStats coro_latency;
+
+  // ThreadPool path
+  double pool_wall_ms = 0.0;
+  LatencyStats pool_latency;
+
+  double speedup_ratio = 0.0;
+  int64_t rss_start_kb = 0;
+  int64_t rss_end_kb = 0;
+};
+
+// Helper coroutine for sleep benchmark
+static Task<void> sleep_coro(EventLoop& loop, int sleep_ms, std::vector<double>& latencies,
+                             std::mutex& latencies_mutex, std::atomic<int>& completed,
+                             std::promise<void>& done, int total) {
+  auto start = steady_clock::now();
+  co_await SleepMs(loop, sleep_ms);
+  auto end = steady_clock::now();
+
+  double latency_us = duration<double, std::micro>(end - start).count();
+  {
+    std::lock_guard<std::mutex> lock(latencies_mutex);
+    latencies.push_back(latency_us);
+  }
+
+  int prev = completed.fetch_add(1);
+  if (prev == total - 1) {
+    done.set_value();
+  }
+}
+
+static SleepVsPoolResult bench_sleep_vs_pool(int tasks_count, int sleep_ms) {
+  SleepVsPoolResult result;
+  result.tasks = tasks_count;
+  result.sleep_ms = sleep_ms;
+  result.rss_start_kb = get_current_rss_kb();
+
+  // Part C1: EventLoop coroutines
+  {
+    EventLoop loop;
+    loop.Start();
+
+    std::vector<double> latencies;
+    latencies.reserve(tasks_count);
+    std::mutex latencies_mutex;
+    std::atomic<int> completed{0};
+    std::promise<void> done;
+    auto done_future = done.get_future();
+
+    std::vector<Task<void>> coros;
+    coros.reserve(tasks_count);
+    for (int i = 0; i < tasks_count; ++i) {
+      coros.push_back(
+          sleep_coro(loop, sleep_ms, latencies, latencies_mutex, completed, done, tasks_count));
+    }
+
+    auto start = steady_clock::now();
+
+    for (auto& coro : coros) {
+      if (!loop.Post([&coro]() { coro.start(); })) {
+        std::cerr << "Error: loop.Post() failed in sleep_vs_pool (coro path)" << std::endl;
+        return result;  // Return partial result on failure
+      }
+    }
+
+    done_future.wait();
+    auto end = steady_clock::now();
+
+    loop.Stop();
+
+    result.coro_wall_ms = duration<double, std::milli>(end - start).count();
+    result.coro_latency = compute_latency_stats(latencies);
+  }
+
+  // Part C2: ThreadPool sleep_for
+  {
+    // Create a pool with number of threads equal to hardware concurrency
+    size_t num_threads = std::thread::hardware_concurrency();
+    if (num_threads == 0) {
+      num_threads = 4;
+    }
+    rankd::ThreadPool pool(num_threads);
+
+    std::vector<double> latencies;
+    latencies.reserve(tasks_count);
+    std::mutex latencies_mutex;
+    std::atomic<int> completed{0};
+    std::promise<void> done;
+    auto done_future = done.get_future();
+
+    auto start = steady_clock::now();
+
+    for (int i = 0; i < tasks_count; ++i) {
+      pool.submit([&, sleep_ms, tasks_count]() {
+        auto task_start = steady_clock::now();
+        std::this_thread::sleep_for(milliseconds(sleep_ms));
+        auto task_end = steady_clock::now();
+
+        double latency_us = duration<double, std::micro>(task_end - task_start).count();
+        {
+          std::lock_guard<std::mutex> lock(latencies_mutex);
+          latencies.push_back(latency_us);
+        }
+
+        int prev = completed.fetch_add(1);
+        if (prev == tasks_count - 1) {
+          done.set_value();
+        }
+      });
+    }
+
+    done_future.wait();
+    auto end = steady_clock::now();
+
+    pool.wait_idle();
+
+    result.pool_wall_ms = duration<double, std::milli>(end - start).count();
+    result.pool_latency = compute_latency_stats(latencies);
+  }
+
+  result.speedup_ratio = result.pool_wall_ms / result.coro_wall_ms;
+  result.rss_end_kb = get_current_rss_kb();
+
+  return result;
+}
+
+// =============================================================================
+// Output formatting
+// =============================================================================
+
+static void format_throughput(std::ostream& os, double value) {
+  if (value >= 1e6) {
+    os << std::fixed << std::setprecision(2) << (value / 1e6) << "M";
+  } else if (value >= 1e3) {
+    os << std::fixed << std::setprecision(2) << (value / 1e3) << "K";
+  } else {
+    os << std::fixed << std::setprecision(1) << value;
+  }
+}
+
+static void print_posts_human(const PostsBenchResult& r) {
+  std::cout << "=== EventLoop Benchmark: posts ===" << std::endl;
+  std::cout << "  Total posts:     " << r.total_posts << std::endl;
+  std::cout << "  Producers:       " << r.producers << std::endl;
+  std::cout << "  Wall time:       " << std::fixed << std::setprecision(1) << r.wall_ms << " ms"
+            << std::endl;
+  std::cout << "  Throughput:      ";
+  format_throughput(std::cout, r.posts_per_sec);
+  std::cout << " posts/sec" << std::endl;
+  std::cout << "  RSS start/end:   " << std::fixed << std::setprecision(1)
+            << (r.rss_start_kb / 1024.0) << " / " << (r.rss_end_kb / 1024.0) << " MB" << std::endl;
+  std::cout << std::endl;
+}
+
+static void print_timers_human(const TimersBenchResult& r) {
+  std::cout << "=== EventLoop Benchmark: timers (uv_timer " << r.timeout_ms << "ms) ===" << std::endl;
+  std::cout << "  Total timers:    " << r.total_timers << std::endl;
+  std::cout << "  Timeout:         " << r.timeout_ms << " ms" << std::endl;
+  std::cout << "  Wall time:       " << std::fixed << std::setprecision(1) << r.wall_ms << " ms"
+            << std::endl;
+  std::cout << "  Throughput:      ";
+  format_throughput(std::cout, r.timers_per_sec);
+  std::cout << " timers/sec" << std::endl;
+  std::cout << "  Latency p50/p90/p99: " << std::fixed << std::setprecision(0) << r.latency.p50_us
+            << "/" << r.latency.p90_us << "/" << r.latency.p99_us << " us" << std::endl;
+  std::cout << "  Latency max/mean:    " << std::fixed << std::setprecision(0) << r.latency.max_us
+            << "/" << r.latency.mean_us << " us" << std::endl;
+  std::cout << "  RSS start/end:   " << std::fixed << std::setprecision(1)
+            << (r.rss_start_kb / 1024.0) << " / " << (r.rss_end_kb / 1024.0) << " MB" << std::endl;
+  std::cout << std::endl;
+}
+
+static void print_sleep_vs_pool_human(const SleepVsPoolResult& r) {
+  std::cout << "=== EventLoop Benchmark: sleep_vs_pool ===" << std::endl;
+  std::cout << "  Tasks:           " << r.tasks << std::endl;
+  std::cout << "  Sleep:           " << r.sleep_ms << " ms" << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "  Coroutine path:" << std::endl;
+  std::cout << "    Wall time:     " << std::fixed << std::setprecision(1) << r.coro_wall_ms
+            << " ms" << std::endl;
+  std::cout << "    Latency p50/p90/p99: " << std::fixed << std::setprecision(0)
+            << r.coro_latency.p50_us << "/" << r.coro_latency.p90_us << "/"
+            << r.coro_latency.p99_us << " us" << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "  ThreadPool path:" << std::endl;
+  std::cout << "    Wall time:     " << std::fixed << std::setprecision(1) << r.pool_wall_ms
+            << " ms" << std::endl;
+  std::cout << "    Latency p50/p90/p99: " << std::fixed << std::setprecision(0)
+            << r.pool_latency.p50_us << "/" << r.pool_latency.p90_us << "/"
+            << r.pool_latency.p99_us << " us" << std::endl;
+  std::cout << std::endl;
+
+  std::cout << "  Speedup (pool/coro): " << std::fixed << std::setprecision(1) << r.speedup_ratio
+            << "x" << std::endl;
+  std::cout << "  RSS start/end:   " << std::fixed << std::setprecision(1)
+            << (r.rss_start_kb / 1024.0) << " / " << (r.rss_end_kb / 1024.0) << " MB" << std::endl;
+  std::cout << std::endl;
+}
+
+static json latency_to_json(const LatencyStats& l) {
+  json j;
+  j["min_us"] = l.min_us;
+  j["max_us"] = l.max_us;
+  j["mean_us"] = l.mean_us;
+  j["p50_us"] = l.p50_us;
+  j["p90_us"] = l.p90_us;
+  j["p99_us"] = l.p99_us;
+  j["count"] = l.count;
+  return j;
+}
+
+static json posts_to_json(const PostsBenchResult& r) {
+  json j;
+  j["total_posts"] = r.total_posts;
+  j["producers"] = r.producers;
+  j["wall_ms"] = r.wall_ms;
+  j["posts_per_sec"] = r.posts_per_sec;
+  j["rss_start_kb"] = r.rss_start_kb;
+  j["rss_end_kb"] = r.rss_end_kb;
+  return j;
+}
+
+static json timers_to_json(const TimersBenchResult& r) {
+  json j;
+  j["total_timers"] = r.total_timers;
+  j["timeout_ms"] = r.timeout_ms;
+  j["wall_ms"] = r.wall_ms;
+  j["timers_per_sec"] = r.timers_per_sec;
+  j["latency"] = latency_to_json(r.latency);
+  j["rss_start_kb"] = r.rss_start_kb;
+  j["rss_end_kb"] = r.rss_end_kb;
+  return j;
+}
+
+static json sleep_vs_pool_to_json(const SleepVsPoolResult& r) {
+  json j;
+  j["tasks"] = r.tasks;
+  j["sleep_ms"] = r.sleep_ms;
+  j["coro_wall_ms"] = r.coro_wall_ms;
+  j["coro_latency"] = latency_to_json(r.coro_latency);
+  j["pool_wall_ms"] = r.pool_wall_ms;
+  j["pool_latency"] = latency_to_json(r.pool_latency);
+  j["speedup_ratio"] = r.speedup_ratio;
+  j["rss_start_kb"] = r.rss_start_kb;
+  j["rss_end_kb"] = r.rss_end_kb;
+  return j;
+}
+
+// =============================================================================
+// Main entry point
+// =============================================================================
+
+int run_bench_eventloop(const BenchEventLoopConfig& config) {
+  bool run_posts = (config.mode == "all" || config.mode == "posts");
+  bool run_timers = (config.mode == "all" || config.mode == "timers");
+  bool run_sleep = (config.mode == "all" || config.mode == "sleep_vs_pool");
+
+  // Validate mode
+  if (!run_posts && !run_timers && !run_sleep) {
+    std::cerr << "Error: invalid bench_eventloop_mode '" << config.mode << "'" << std::endl;
+    std::cerr << "Valid modes: posts, timers, sleep_vs_pool, all" << std::endl;
+    return 1;
+  }
+
+  json json_output;
+
+  // Mode A: posts
+  if (run_posts) {
+    int n = config.n;
+    if (n == 0) {
+      n = 1000000;  // 1M posts - same for all producer counts for fair comparison
+    }
+
+    auto result = bench_posts(n, config.producers);
+
+    if (config.json_output) {
+      json_output["posts"] = posts_to_json(result);
+    } else {
+      print_posts_human(result);
+    }
+  }
+
+  // Mode B: timers (raw uv_timer_t scheduling)
+  if (run_timers) {
+    int n = config.n;
+    if (n == 0) {
+      n = 10000;
+    }
+
+    // Use config.sleep_ms for timer timeout (default 0 = immediate fire)
+    auto result = bench_timers(n, config.sleep_ms);
+
+    if (config.json_output) {
+      json_output["timers"] = timers_to_json(result);
+    } else {
+      print_timers_human(result);
+    }
+  }
+
+  // Mode C: sleep_vs_pool
+  if (run_sleep) {
+    auto result = bench_sleep_vs_pool(config.tasks, config.sleep_ms);
+
+    if (config.json_output) {
+      json_output["sleep_vs_pool"] = sleep_vs_pool_to_json(result);
+    } else {
+      print_sleep_vs_pool_human(result);
+    }
+  }
+
+  if (config.json_output) {
+    std::cout << json_output.dump(2) << std::endl;
+  }
+
+  return 0;
+}
+
+}  // namespace ranking


### PR DESCRIPTION
## Summary
- Add EventLoop micro-benchmarking for throughput and latency measurement
- Three benchmark modes: `posts`, `timers`, `sleep_vs_pool`
- CLI flags for configuring iterations, producer threads, sleep duration, output format
- No external dependencies (Redis/plans) required - early exit before loading
- Fix `AsyncWithTimeout` hang on synchronous completion during shutdown (Codex finding)
- **Critical bug fix**: Coroutine lifetime race in `execute_plan_async_blocking` (caused SIGSEGV at high iteration counts)
- **Additional fix**: UV_POLL handle double-close during EventLoop shutdown
- **Shutdown ordering fix**: CPU pool drain while loop running, then stop
- Add VM performance testing infrastructure (`docs/PERF_VM.md`, `scripts/perf_throughput_sweep.sh`, `scripts/plot_perf_sweep.py`)

---

## Critical Bug Fix: Coroutine Lifetime Race

### The Problem

When running async scheduler benchmarks with high iteration counts (3000+), the engine would crash with SIGSEGV (exit code 139). Address Sanitizer revealed a use-after-free in coroutine destruction.

### Root Cause Analysis

In `execute_plan_async_blocking()`, a wrapper coroutine is created and started on the EventLoop thread. The original code signaled completion by setting `done=true` and calling `done_cv.notify_one()` from the coroutine body. However, this signaling happened **before** the coroutine reached `final_suspend`:

```cpp
// PROBLEMATIC: In wrapper coroutine (event loop thread):
{
  std::lock_guard<std::mutex> lock(done_mutex);
  done = true;
}
done_cv.notify_one();
// ↑ Main thread can wake up here!
// ↓ But coroutine is still running...
// implicit co_return → return_void() → final_suspend() → await_suspend()
```

This creates a race condition:

```
Timeline (race scenario):
═══════════════════════════════════════════════════════════════════════════════
Event Loop Thread (T9)                    Main Thread (T0)
═══════════════════════════════════════════════════════════════════════════════
wrapper coroutine executing...
├─ result = co_await execute_plan_async()
├─ ... async work completes ...
├─ {
│    lock(done_mutex);
│    done = true;                         
│  }
├─ done_cv.notify_one();
│                                         ├─ wakes from done_cv.wait()
│  (coroutine still running!)             ├─ checks error, moves result
│  (hasn't reached final_suspend yet)     ├─ function returns
│                                         ├─ Task<void> task goes out of scope
│                                         ├─ ~Task() called
│                                         └─ handle_.destroy() ← FREES FRAME
│
├─ tries to continue execution...
└─ CRASH: accessing freed coroutine frame
═══════════════════════════════════════════════════════════════════════════════
```

### The Fix: Signal from `final_suspend`

Instead of signaling from the coroutine body, we use a custom `BlockingTask` type that signals completion from `final_suspend`. This guarantees the coroutine is **suspended** (not running) when the main thread wakes up:

```cpp
struct BlockingPromise {
  std::mutex* done_mutex_;
  bool* done_;
  std::condition_variable* done_cv_;

  // Signal completion from final_suspend - coroutine is guaranteed suspended
  auto final_suspend() noexcept {
    struct SignalingAwaiter {
      BlockingPromise& p;
      bool await_ready() noexcept { return false; }
      void await_suspend(std::coroutine_handle<>) noexcept {
        // Safe to signal - we're at final_suspend, coroutine won't run again
        {
          std::lock_guard<std::mutex> lock(*p.done_mutex_);
          *p.done_ = true;
        }
        p.done_cv_->notify_one();
      }
      void await_resume() noexcept {}
    };
    return SignalingAwaiter{*this};
  }
  // ...
};
```

Key insight: `final_suspend`'s `await_suspend` runs **after** the coroutine body has completed and **after** `return_void()`. When we signal from here, the coroutine is in a stable suspended state and safe to destroy from any thread.

This avoids:
1. Cross-thread polling of `coroutine_handle::done()` (potential UB)
2. Any race window between signaling and reaching final_suspend

---

## Additional Fix: UV_POLL Handle Double-Close

### Problem

During EventLoop shutdown with active Redis connections, the engine would assert-fail:
```
Assertion failed: (!uv__is_closing(handle))
```

### Root Cause

`CloseWalkCallback` was attempting to close `UV_POLL` handles that are owned and managed by hiredis. When hiredis later tried to clean up, double-close assertion.

### Fix

Skip `UV_POLL` handles in the cleanup walk - they're externally owned:

```cpp
if (handle->type == UV_POLL) {
  return;  // Owned by hiredis, don't close
}
```

---

## Shutdown Ordering Fix

### Problem

Original ordering was:
1. `async_clients.reset()` - disconnect Redis
2. `loop->Stop()` - stop event loop
3. `GetCPUThreadPool().wait_idle()` - wait for CPU tasks

But CPU offload completions need to `Post()` back to the loop. If the loop is already stopping, those Posts fail.

### Fix

Drain CPU pool **while loop is still running**:
1. `async_clients.reset()` - disconnect Redis  
2. `GetCPUThreadPool().wait_idle()` - wait for CPU tasks (can still Post)
3. `loop->Stop()` - now safe to stop

---

## Benchmark Results

### Hardware
- **CPU**: Apple M4 (10 cores)
- **RAM**: 32 GB
- **OS**: macOS 26.2

### EventLoop Micro-benchmarks

| Mode | Configuration | Metric | Result |
|------|--------------|--------|--------|
| `posts` | 1 producer, 1M posts | Throughput | **52.0M posts/sec** |
| `posts` | 4 producers, 1M posts | Throughput | **17.9M posts/sec** |
| `timers` | 10K timers (uv_timer 0ms) | Throughput | **5.1M timers/sec** |
| `timers` | 10K timers (uv_timer 0ms) | Latency p50/p99 | **1034/1253 us** |
| `sleep_vs_pool` | 1000 tasks × 1ms | Coroutine wall time | **1.3 ms** |
| `sleep_vs_pool` | 1000 tasks × 1ms | ThreadPool wall time | **124.6 ms** |
| `sleep_vs_pool` | 1000 tasks × 1ms | **Speedup** | **94.7x** |

### High-Iteration Async Scheduler Benchmarks (Post-Fix)

**Sequential execution:**
```bash
$ echo '{"user_id": 1}' | engine/bin/rankd --bench 3000 --async_scheduler --plan_name reels_plan_a
{
  "iterations": 3000,
  "throughput_rps": 1474.0,
  "p50_us": 670.3,
  "p99_us": 994.1
}
```

**Concurrent execution:**
```bash
$ echo '{"user_id": 1}' | engine/bin/rankd --bench 500 --bench_concurrency 4 --async_scheduler --plan_name reels_plan_a
{
  "iterations": 500,
  "concurrency": 4,
  "throughput_rps": 4568.8,
  "p50_us": 796.3,
  "p99_us": 1414.9
}
```

Previously crashed at ~3000 iterations with SIGSEGV.

### Concurrency Sweep (`concat_plan` with Redis)

**Note**: `concat_plan` hits real Redis (`viewer`, `follow`, `recommendation` tasks). Results reflect actual Redis I/O.

| Concurrency | QPS | p50 (μs) | p99 (μs) | max (μs) | Assessment |
|-------------|-----|----------|----------|----------|------------|
| 1 | 2,631 | 363 | 544 | 2,553 | Baseline |
| 2 | 5,036 | 390 | 474 | 1,317 | Near-linear (1.9x) |
| 4 | 8,957 | 436 | 551 | 1,236 | Near-linear (3.4x) |
| 8 | 14,612 | 528 | 1,296 | 1,304 | Good scaling (5.6x) |
| 16 | 20,357 | 747 | 1,430 | 1,439 | Still scaling (7.7x) |
| 32 | 26,245 | 1,164 | 1,831 | 1,876 | **Knee** (10x, p99↑) |
| 64 | 27,695 | 2,156 | 3,074 | 3,081 | Saturated (10.5x) |

**Analysis**:
- **Knee at c=32**: QPS gain 32→64 is only 5.5%, but p99 jumps 68% (1831→3074 μs)
- **Recommended operating point**: c=16–24 (still in linear scaling region, p99 < 2ms)
- **Peak throughput**: ~27.7K RPS at c=64, but tail latency doubles
- The `concat_plan` saturates at ~27K RPS on this hardware (M4, local Redis)

---

## Files

| File | Action |
|------|--------|
| `engine/include/bench_stats.h` | New - LatencyStats, percentiles, RSS |
| `engine/include/bench_event_loop.h` | New - BenchConfig, run_bench_eventloop() |
| `engine/src/bench_event_loop.cpp` | New - All benchmark implementations |
| `engine/include/cpu_offload.h` | Fix - AsyncWithTimeout sync completion hang |
| `engine/src/async_dag_scheduler.cpp` | **Fix - BlockingTask with final_suspend signaling** |
| `engine/src/event_loop.cpp` | **Fix - UV_POLL double-close** |
| `engine/src/main.cpp` | Add CLI flags, **fix shutdown ordering** |
| `engine/CMakeLists.txt` | Add source file |
| `docs/EVENT_LOOP_BENCH.md` | New - Usage docs |
| `docs/PERF_VM.md` | New - VM setup guide for safe benchmarking |
| `docs/IMPLEMENTATION_PROGRESS.md` | Mark step complete, document fixes |
| `scripts/perf_throughput_sweep.sh` | New - Throughput/latency sweep script |
| `scripts/plot_perf_sweep.py` | New - Generate plots from sweep CSV |

## Test plan
- [x] `engine/bin/rankd --bench_eventloop` runs all modes
- [x] `--bench_eventloop_mode posts --bench_producers 4` tests multi-producer
- [x] `--bench_eventloop_mode sleep_vs_pool --bench_tasks 500` tests custom params
- [x] `--bench_json` produces valid JSON output
- [x] All existing tests pass (290 + 88 + 138 assertions)
- [x] **3000 iterations with async scheduler completes without crash**
- [x] **500 iterations with concurrency=4 completes without crash**
- [x] Throughput sweep script runs successfully
- [x] Plotting script generates all 3 plots + knee summary
- [x] Concurrency sweep 1→64 shows knee at c=32, peak ~27K RPS

🤖 Generated with [Claude Code](https://claude.ai/code)
